### PR TITLE
#2 Add crap-typescript gate to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,3 +60,26 @@ jobs:
 
       - name: Run cognitive-typescript gate
         run: npm run cognitive-typescript-check
+
+  crap-typescript-gate:
+    name: crap-typescript Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run crap-typescript gate
+        run: npm run crap-typescript-check

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ npm ci
 npm run build
 npm test
 npm run cognitive-typescript-check
+npm run crap-typescript-check
 npm pack --workspaces
 ```
 
 `npm run cognitive-typescript-check` runs the repository through its own Cognitive Complexity gate for the published package sources under `packages/`.
+`npm run crap-typescript-check` runs the repository through a CRAP gate using the published Vitest adapter for the package sources under `packages/`.
 
 ## Install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@barney-media/crap-typescript-vitest": "^0.2.1",
         "@types/node": "^25.5.1",
+        "@vitest/coverage-v8": "^4.1.2",
         "jest": "^30.3.0",
         "ts-jest": "^29.4.9",
         "typescript": "^6.0.2",
@@ -500,6 +502,45 @@
       "resolved": "packages/vitest",
       "link": true
     },
+    "node_modules/@barney-media/crap-typescript-core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-core/-/crap-typescript-core-0.2.1.tgz",
+      "integrity": "sha512-QMAvgB1Nsk+XkVZsFQn4ttP6uaSbLSJPgFvJeVLG/r5DGg7ZthQOZL0+Fm6MEJsmwJ8PE2S0Ud8qHtdAv2s3mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "typescript": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@barney-media/crap-typescript-vitest": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-vitest/-/crap-typescript-vitest-0.2.1.tgz",
+      "integrity": "sha512-6+6EIMDVZ7itJUae9gKjbkMmiaA6f1iv5wnoujmNzpSiwPQBj7LyxiJaQtb5iU/kdMgp0Xxx9p3Wj8++07NdzQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@barney-media/crap-typescript-core": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "vitest": "^4.0.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -938,9 +979,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -969,9 +1010,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
       "cpu": [
         "arm64"
       ],
@@ -985,9 +1026,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
       "cpu": [
         "arm64"
       ],
@@ -1001,9 +1042,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
       "cpu": [
         "x64"
       ],
@@ -1017,9 +1058,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
       "cpu": [
         "x64"
       ],
@@ -1033,9 +1074,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
       "cpu": [
         "arm"
       ],
@@ -1049,9 +1090,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
       "cpu": [
         "arm64"
       ],
@@ -1065,9 +1106,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1081,9 +1122,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1097,9 +1138,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
       ],
@@ -1113,9 +1154,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
       "cpu": [
         "x64"
       ],
@@ -1129,9 +1170,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
       ],
@@ -1145,9 +1186,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
       "cpu": [
         "arm64"
       ],
@@ -1161,25 +1202,27 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1195,9 +1238,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
       "cpu": [
         "arm64"
       ],
@@ -1211,9 +1254,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -1227,9 +1270,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
@@ -1645,16 +1688,48 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1663,12 +1738,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1689,9 +1764,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
@@ -1701,12 +1776,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1714,13 +1789,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1729,21 +1804,21 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1834,6 +1909,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3389,6 +3476,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
@@ -3731,6 +3825,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -4114,9 +4220,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4220,13 +4326,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4235,21 +4341,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/semver": {
@@ -4627,13 +4733,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4877,16 +4983,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
-      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.15",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -4955,19 +5061,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4995,10 +5101,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5020,6 +5128,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,15 @@
   "scripts": {
     "build": "tsc -b packages/core packages/cli packages/vitest packages/jest",
     "cognitive-typescript-check": "npm run build && vitest run --config vitest.cognitive.config.ts",
+    "crap-typescript-check": "npm run build && vitest run --config vitest.crap.config.ts",
     "test": "npm run build && vitest run",
     "pack": "npm pack --workspaces",
     "verify-release-version": "node ./scripts/verify-release-version.mjs"
   },
   "devDependencies": {
+    "@barney-media/crap-typescript-vitest": "^0.2.1",
     "@types/node": "^25.5.1",
+    "@vitest/coverage-v8": "^4.1.2",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.9",
     "typescript": "^6.0.2",

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -36,38 +36,11 @@ export function parseCliArguments(args: string[]): CliArguments {
     return { mode: "all", fileArgs: [] };
   }
 
-  const state = {
-    help: false,
-    changed: false,
-    fileArgs: [] as string[]
-  };
-
+  const state = createCliParseState();
   for (const arg of args) {
-    if (!arg.startsWith("--")) {
-      state.fileArgs.push(arg);
-      continue;
-    }
-    if (arg === "--help") {
-      state.help = true;
-      continue;
-    }
-    if (arg === "--changed") {
-      state.changed = true;
-      continue;
-    }
-    throw new Error(`Unknown option: ${arg}`);
+    applyCliArgument(state, arg);
   }
-
-  if (state.help) {
-    return { mode: "help", fileArgs: [] };
-  }
-  if (state.changed && state.fileArgs.length > 0) {
-    throw new Error("--changed cannot be combined with file arguments");
-  }
-  return {
-    mode: state.changed ? "changed" : state.fileArgs.length > 0 ? "explicit" : "all",
-    fileArgs: state.fileArgs
-  };
+  return finalizeCliArguments(state);
 }
 
 export async function runCli(
@@ -134,4 +107,59 @@ async function analyzeCliProject(
     writeLine(stderr, (error as Error).message);
     return null;
   }
+}
+
+interface CliParseState {
+  help: boolean;
+  changed: boolean;
+  fileArgs: string[];
+}
+
+function createCliParseState(): CliParseState {
+  return {
+    help: false,
+    changed: false,
+    fileArgs: []
+  };
+}
+
+function applyCliArgument(state: CliParseState, arg: string): void {
+  if (!arg.startsWith("--")) {
+    state.fileArgs.push(arg);
+    return;
+  }
+  applyCliOption(state, arg);
+}
+
+function applyCliOption(state: CliParseState, arg: string): void {
+  switch (arg) {
+    case "--help":
+      state.help = true;
+      return;
+    case "--changed":
+      state.changed = true;
+      return;
+    default:
+      throw new Error(`Unknown option: ${arg}`);
+  }
+}
+
+function finalizeCliArguments(state: CliParseState): CliArguments {
+  if (state.help) {
+    return { mode: "help", fileArgs: [] };
+  }
+  if (state.changed && state.fileArgs.length > 0) {
+    throw new Error("--changed cannot be combined with file arguments");
+  }
+  return {
+    mode: resolveCliMode(state),
+    fileArgs: state.fileArgs
+  };
+}
+
+function resolveCliMode(state: CliParseState): CliArguments["mode"] {
+  if (state.changed) {
+    return "changed";
+  }
+  return state.fileArgs.length > 0 ? "explicit" : "all";
 }

--- a/packages/core/src/cognitiveComplexity.ts
+++ b/packages/core/src/cognitiveComplexity.ts
@@ -41,25 +41,11 @@ export function analyzeFunctionBody(
 
   const scanLogicalExpression = (node: ts.Expression, nesting: number, previousOperator: LogicalOperator): void => {
     const expression = unwrapParentheses(node);
-    if (ts.isPrefixUnaryExpression(expression) && expression.operator === ts.SyntaxKind.ExclamationToken) {
-      scanLogicalExpression(expression.operand, nesting, null);
+    if (scanNegatedLogicalExpression(expression, nesting)) {
       return;
     }
-    if (ts.isBinaryExpression(expression)) {
-      const operator = logicalOperator(expression.operatorToken.kind);
-      if (operator === "??") {
-        scan(expression.left, nesting);
-        scan(expression.right, nesting);
-        return;
-      }
-      if (operator) {
-        if (previousOperator !== operator) {
-          addFundamental();
-        }
-        scanLogicalExpression(expression.left, nesting, operator);
-        scanLogicalExpression(expression.right, nesting, operator);
-        return;
-      }
+    if (scanLogicalBinaryExpression(expression, nesting, previousOperator)) {
+      return;
     }
     scan(expression, nesting);
   };
@@ -211,6 +197,63 @@ export function analyzeFunctionBody(
     return false;
   };
 
+  const scanNegatedLogicalExpression = (expression: ts.Expression, nesting: number): boolean => {
+    if (!(ts.isPrefixUnaryExpression(expression) && expression.operator === ts.SyntaxKind.ExclamationToken)) {
+      return false;
+    }
+    scanLogicalExpression(expression.operand, nesting, null);
+    return true;
+  };
+
+  const scanLogicalBinaryExpression = (
+    expression: ts.Expression,
+    nesting: number,
+    previousOperator: LogicalOperator
+  ): boolean => {
+    if (!ts.isBinaryExpression(expression)) {
+      return false;
+    }
+    const operator = logicalOperator(expression.operatorToken.kind);
+    if (!operator) {
+      return false;
+    }
+    return handleTrackedLogicalOperator(expression, nesting, previousOperator, operator);
+  };
+
+  const handleTrackedLogicalOperator = (
+    expression: ts.BinaryExpression,
+    nesting: number,
+    previousOperator: LogicalOperator,
+    operator: "&&" | "||" | "??"
+  ): boolean => {
+    if (operator === "??") {
+      scan(expression.left, nesting);
+      scan(expression.right, nesting);
+      return true;
+    }
+    if (previousOperator !== operator) {
+      addFundamental();
+    }
+    scanLogicalExpression(expression.left, nesting, operator);
+    scanLogicalExpression(expression.right, nesting, operator);
+    return true;
+  };
+
+  const nodeHandlers = [
+    handleIfStatement,
+    handleForStatement,
+    handleForEachStatement,
+    handleWhileStatement,
+    handleDoStatement,
+    handleCaseBlock,
+    handleSwitchStatement,
+    handleCatchClause,
+    handleConditionalExpression,
+    handleJumpStatement,
+    handleCallExpression,
+    handleLogicalBinaryExpression
+  ];
+
   const scan = (node: ts.Node | undefined, nesting: number): void => {
     if (!node) {
       return;
@@ -218,41 +261,10 @@ export function analyzeFunctionBody(
     if (node !== root && isNestedFunctionLike(node)) {
       return;
     }
-    if (handleIfStatement(node, nesting)) {
-      return;
-    }
-    if (handleForStatement(node, nesting)) {
-      return;
-    }
-    if (handleForEachStatement(node, nesting)) {
-      return;
-    }
-    if (handleWhileStatement(node, nesting)) {
-      return;
-    }
-    if (handleDoStatement(node, nesting)) {
-      return;
-    }
-    if (handleCaseBlock(node, nesting)) {
-      return;
-    }
-    if (handleSwitchStatement(node, nesting)) {
-      return;
-    }
-    if (handleCatchClause(node, nesting)) {
-      return;
-    }
-    if (handleConditionalExpression(node, nesting)) {
-      return;
-    }
-    if (handleJumpStatement(node)) {
-      return;
-    }
-    if (handleCallExpression(node, nesting)) {
-      return;
-    }
-    if (handleLogicalBinaryExpression(node, nesting)) {
-      return;
+    for (const handler of nodeHandlers) {
+      if (handler(node, nesting)) {
+        return;
+      }
     }
     ts.forEachChild(node, (child) => {
       scan(child, nesting);
@@ -264,16 +276,7 @@ export function analyzeFunctionBody(
 }
 
 function resolveCallSymbol(expression: ts.Expression, checker: ts.TypeChecker): ts.Symbol | null {
-  if (ts.isIdentifier(expression)) {
-    return resolveSymbol(expression, checker);
-  }
-  if (ts.isPropertyAccessExpression(expression)) {
-    return resolveSymbol(expression.name, checker);
-  }
-  if (ts.isElementAccessExpression(expression) && expression.argumentExpression) {
-    return resolveSymbol(expression.argumentExpression, checker);
-  }
-  return resolveSymbol(expression, checker);
+  return resolveSymbol(symbolLookupNode(expression), checker);
 }
 
 function resolveSymbol(node: ts.Node, checker: ts.TypeChecker): ts.Symbol | null {
@@ -340,14 +343,8 @@ function isIgnoredJsxLogicalChain(node: ts.BinaryExpression): boolean {
   if (!isLogicalBinary(node)) {
     return false;
   }
-  let current: ts.Node = node;
-  while (ts.isBinaryExpression(current.parent) && isLogicalBinary(current.parent)) {
-    current = current.parent;
-  }
-  if (!hasJsxExpressionAncestor(current)) {
-    return false;
-  }
-  return isJsxLikeNode(rightmostLogicalOperand(current as ts.BinaryExpression));
+  const topmost = topmostLogicalExpression(node);
+  return hasJsxExpressionAncestor(topmost) && isJsxLikeNode(rightmostLogicalOperand(topmost));
 }
 
 function isLogicalBinary(node: ts.Node): node is ts.BinaryExpression {
@@ -380,6 +377,24 @@ function rightmostLogicalOperand(node: ts.BinaryExpression): ts.Node {
 
 function isJsxLikeNode(node: ts.Node): boolean {
   return ts.isJsxElement(node) || ts.isJsxFragment(node) || ts.isJsxSelfClosingElement(node);
+}
+
+function symbolLookupNode(expression: ts.Expression): ts.Node {
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name;
+  }
+  if (ts.isElementAccessExpression(expression) && expression.argumentExpression) {
+    return expression.argumentExpression;
+  }
+  return expression;
+}
+
+function topmostLogicalExpression(node: ts.BinaryExpression): ts.BinaryExpression {
+  let current = node;
+  while (ts.isBinaryExpression(current.parent) && isLogicalBinary(current.parent)) {
+    current = current.parent;
+  }
+  return current;
 }
 
 function unwrapParentheses<T extends ts.Node>(node: T): T {

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -38,11 +38,8 @@ export async function expandExplicitPaths(
 }
 
 export async function changedTypeScriptFilesUnderSourceRoots(projectRoot: string): Promise<string[]> {
-  const result = await runCommand("git", ["status", "--porcelain", "-z"], projectRoot);
-  if (result.exitCode !== 0) {
-    throw new Error(result.stderr.trim() || "git status --porcelain failed");
-  }
-  return Array.from(collectChangedFilesFromStatus(projectRoot, result.stdout.split("\0"))).sort();
+  const entries = await readChangedFileStatusEntries(projectRoot);
+  return Array.from(collectChangedFilesFromStatus(projectRoot, entries)).sort();
 }
 
 export function isAnalyzableFile(filePath: string): boolean {
@@ -109,10 +106,7 @@ function isUnderSourceTree(projectRoot: string, filePath: string): boolean {
 }
 
 function isIncludedGitStatus(status: string): boolean {
-  if (status === "??") {
-    return true;
-  }
-  return !status.includes("D") && /[AMRCU]/.test(status);
+  return status === "??" || isIncludedTrackedStatus(status);
 }
 
 function isRenameOrCopyStatus(status: string): boolean {
@@ -125,6 +119,23 @@ function containsAny(value: string, fragments: string[]): boolean {
 
 function hasAnySuffix(value: string, suffixes: string[]): boolean {
   return suffixes.some((suffix) => value.endsWith(suffix));
+}
+
+async function readChangedFileStatusEntries(projectRoot: string): Promise<string[]> {
+  const result = await runCommand("git", ["status", "--porcelain", "-z"], projectRoot);
+  if (result.exitCode === 0) {
+    return result.stdout.split("\0");
+  }
+  throw new Error(readChangedFileStatusError(result.stderr));
+}
+
+function isIncludedTrackedStatus(status: string): boolean {
+  return !status.includes("D") && /[AMRCU]/.test(status);
+}
+
+function readChangedFileStatusError(stderr: string): string {
+  const message = stderr.trim();
+  return message || "git status --porcelain failed";
 }
 
 async function walkForSourceRoots(

--- a/packages/core/src/functionDiscovery.ts
+++ b/packages/core/src/functionDiscovery.ts
@@ -227,19 +227,14 @@ function shouldIgnoreDeclarativeOuterFunction(node: ts.Node, method: InternalMet
   if (method.baseCognitiveComplexity !== 0) {
     return false;
   }
-  if (!(ts.isFunctionExpression(node) || ts.isArrowFunction(node))) {
+  if (!isTopLevelDeclarativeWrapper(node)) {
     return false;
   }
-  if (!ts.isBlock(node.body)) {
+  const statements = node.body.statements;
+  if (!hasDeclarativeMethodLikeTopLevel(statements)) {
     return false;
   }
-  if (hasEnclosingFunction(node)) {
-    return false;
-  }
-  if (!hasDeclarativeMethodLikeTopLevel(node.body.statements)) {
-    return false;
-  }
-  return node.body.statements.every(isDeclarativeTopLevelStatement);
+  return statements.every(isDeclarativeTopLevelStatement);
 }
 
 function hasEnclosingFunction(node: ts.Node): boolean {
@@ -258,47 +253,25 @@ function hasDeclarativeMethodLikeTopLevel(statements: readonly ts.Statement[]): 
 }
 
 function statementContainsDeclarativeMethodLike(statement: ts.Statement): boolean {
-  if (ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement)) {
+  if (isDeclarativeTypeStatement(statement)) {
     return true;
   }
-  if (ts.isVariableStatement(statement)) {
-    return statement.declarationList.declarations.some((declaration) =>
-      declaration.initializer ? initializerContainsMethodLike(declaration.initializer) : false
-    );
-  }
-  if (ts.isExpressionStatement(statement) && ts.isBinaryExpression(statement.expression)) {
-    return initializerContainsMethodLike(statement.expression.right);
-  }
-  return false;
+  return variableStatementContainsMethodLike(statement) || assignmentStatementContainsMethodLike(statement);
 }
 
 function initializerContainsMethodLike(expression: ts.Expression): boolean {
   const unwrapped = unwrapParentheses(expression);
-  if (ts.isFunctionExpression(unwrapped) || ts.isArrowFunction(unwrapped) || ts.isClassExpression(unwrapped)) {
+  if (isDeclarativeInitializer(unwrapped)) {
     return true;
   }
-  if (ts.isObjectLiteralExpression(unwrapped)) {
-    return unwrapped.properties.some((property) =>
-      ts.isMethodDeclaration(property)
-      || (ts.isPropertyAssignment(property) && initializerContainsMethodLike(property.initializer))
-    );
-  }
-  return false;
+  return ts.isObjectLiteralExpression(unwrapped) && unwrapped.properties.some(isMethodLikeObjectProperty);
 }
 
 function isDeclarativeTopLevelStatement(statement: ts.Statement): boolean {
-  if (
-    ts.isFunctionDeclaration(statement) ||
-    ts.isClassDeclaration(statement) ||
-    ts.isVariableStatement(statement) ||
-    ts.isEmptyStatement(statement)
-  ) {
+  if (isAlwaysDeclarativeStatement(statement)) {
     return true;
   }
-  return ts.isExpressionStatement(statement)
-    && ts.isBinaryExpression(statement.expression)
-    && statement.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken
-    && initializerContainsMethodLike(statement.expression.right);
+  return assignmentStatementContainsMethodLike(statement);
 }
 
 function inferAnonymousDefaultName(node: ts.FunctionDeclaration): string | null {
@@ -406,14 +379,9 @@ function assignedNameFromBinaryExpression(
 function findContainerName(node: ts.Node): string | null {
   let current: ts.Node | undefined = node.parent;
   while (current) {
-    if ((ts.isClassDeclaration(current) || ts.isClassExpression(current)) && current.name) {
-      return current.name.text;
-    }
-    if (ts.isObjectLiteralExpression(current)) {
-      const inferred = inferObjectContainerName(current);
-      if (inferred) {
-        return inferred;
-      }
+    const containerName = containerNameFromNode(current);
+    if (containerName) {
+      return containerName;
     }
     current = current.parent;
   }
@@ -461,7 +429,7 @@ function containerFromPropertyDeclaration(parent: ts.Node): string | null {
 }
 
 function containerFromBinaryAssignment(parent: ts.Node): string | null {
-  if (!ts.isBinaryExpression(parent) || parent.operatorToken.kind !== ts.SyntaxKind.EqualsToken) {
+  if (!isAssignmentBinaryExpression(parent)) {
     return null;
   }
   const target = assignmentTarget(parent.left);
@@ -469,28 +437,13 @@ function containerFromBinaryAssignment(parent: ts.Node): string | null {
 }
 
 function assignmentTarget(node: ts.Expression): { name: string; containerName: string | null } {
-  if (ts.isIdentifier(node)) {
-    return {
-      name: node.text,
-      containerName: null
-    };
+  for (const resolver of ASSIGNMENT_TARGET_RESOLVERS) {
+    const target = resolver(node);
+    if (target) {
+      return target;
+    }
   }
-  if (ts.isPropertyAccessExpression(node)) {
-    return {
-      name: node.name.text,
-      containerName: node.expression.getText()
-    };
-  }
-  if (ts.isElementAccessExpression(node)) {
-    return {
-      name: `[${node.argumentExpression?.getText() ?? ""}]`,
-      containerName: node.expression.getText()
-    };
-  }
-  return {
-    name: "<assigned>",
-    containerName: null
-  };
+  return createAssignmentTarget("<assigned>", null);
 }
 
 function propertyName(name: ts.PropertyName): string {
@@ -535,4 +488,87 @@ function normalizeFilePath(filePath: string): string {
 
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values));
+}
+
+type DeclarativeWrapper = (ts.FunctionExpression | ts.ArrowFunction) & { body: ts.Block };
+
+function isTopLevelDeclarativeWrapper(node: ts.Node): node is DeclarativeWrapper {
+  return (ts.isFunctionExpression(node) || ts.isArrowFunction(node))
+    && ts.isBlock(node.body)
+    && !hasEnclosingFunction(node);
+}
+
+function isDeclarativeTypeStatement(statement: ts.Statement): boolean {
+  return ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement);
+}
+
+function variableStatementContainsMethodLike(statement: ts.Statement): boolean {
+  return ts.isVariableStatement(statement)
+    && statement.declarationList.declarations.some((declaration) =>
+      declaration.initializer ? initializerContainsMethodLike(declaration.initializer) : false
+    );
+}
+
+function assignmentStatementContainsMethodLike(statement: ts.Statement): boolean {
+  return ts.isExpressionStatement(statement)
+    && isAssignmentBinaryExpression(statement.expression)
+    && initializerContainsMethodLike(statement.expression.right);
+}
+
+function isDeclarativeInitializer(expression: ts.Expression): boolean {
+  return ts.isFunctionExpression(expression) || ts.isArrowFunction(expression) || ts.isClassExpression(expression);
+}
+
+function isAlwaysDeclarativeStatement(statement: ts.Statement): boolean {
+  return isDeclarativeTypeStatement(statement) || ts.isVariableStatement(statement) || ts.isEmptyStatement(statement);
+}
+
+function containerNameFromNode(node: ts.Node): string | null {
+  if ((ts.isClassDeclaration(node) || ts.isClassExpression(node)) && node.name) {
+    return node.name.text;
+  }
+  return ts.isObjectLiteralExpression(node) ? inferObjectContainerName(node) : null;
+}
+
+function isAssignmentBinaryExpression(node: ts.Node): node is ts.BinaryExpression {
+  return ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken;
+}
+
+function createAssignmentTarget(name: string, containerName: string | null): { name: string; containerName: string | null } {
+  return { name, containerName };
+}
+
+type AssignmentTargetResolver = (node: ts.Expression) => { name: string; containerName: string | null } | null;
+
+const ASSIGNMENT_TARGET_RESOLVERS: AssignmentTargetResolver[] = [
+  assignmentTargetFromIdentifier,
+  assignmentTargetFromPropertyAccess,
+  assignmentTargetFromElementAccess
+];
+
+function assignmentTargetFromIdentifier(node: ts.Expression): { name: string; containerName: string | null } | null {
+  return ts.isIdentifier(node) ? createAssignmentTarget(node.text, null) : null;
+}
+
+function assignmentTargetFromPropertyAccess(node: ts.Expression): { name: string; containerName: string | null } | null {
+  return ts.isPropertyAccessExpression(node)
+    ? createAssignmentTarget(node.name.text, node.expression.getText())
+    : null;
+}
+
+function assignmentTargetFromElementAccess(node: ts.Expression): { name: string; containerName: string | null } | null {
+  return ts.isElementAccessExpression(node)
+    ? createAssignmentTarget(`[${node.argumentExpression?.getText() ?? ""}]`, node.expression.getText())
+    : null;
+}
+
+function isMethodLikeObjectProperty(property: ts.ObjectLiteralElementLike): boolean {
+  if (ts.isMethodDeclaration(property)) {
+    return true;
+  }
+  return isMethodLikePropertyAssignment(property);
+}
+
+function isMethodLikePropertyAssignment(property: ts.ObjectLiteralElementLike): boolean {
+  return ts.isPropertyAssignment(property) && initializerContainsMethodLike(property.initializer);
 }

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -18,61 +18,13 @@ export async function analyzeTypeScriptFiles(filePaths: string[]): Promise<Parse
     return [];
   }
 
-  const program = ts.createProgram({
-    rootNames: resolvedFiles,
-    options: {
-      allowJs: false,
-      checkJs: false,
-      jsx: ts.JsxEmit.Preserve,
-      module: ts.ModuleKind.Node16,
-      moduleResolution: ts.ModuleResolutionKind.Node16,
-      noEmit: true,
-      resolveJsonModule: true,
-      skipLibCheck: true,
-      target: ts.ScriptTarget.ES2022
-    }
-  });
-  const checker = program.getTypeChecker();
   const selectedFiles = new Set(resolvedFiles.map(normalizeFilePath));
-
-  for (const sourceFile of program.getSourceFiles()) {
-    if (!selectedFiles.has(normalizeFilePath(sourceFile.fileName))) {
-      continue;
-    }
-    const diagnostics = program.getSyntacticDiagnostics(sourceFile);
-    if (diagnostics.length > 0) {
-      throw new Error(formatDiagnostics(diagnostics));
-    }
-  }
-
-  const methods: InternalMethod[] = [];
-  for (const sourceFile of program.getSourceFiles()) {
-    if (!selectedFiles.has(normalizeFilePath(sourceFile.fileName))) {
-      continue;
-    }
-    methods.push(...collectMethodsFromSourceFile(sourceFile, checker));
-  }
-
+  const program = createTypeScriptProgram(resolvedFiles);
+  const selectedSourceFiles = selectProgramSourceFiles(program, selectedFiles);
+  ensureSelectedFilesParse(program, selectedSourceFiles);
+  const methods = collectSelectedMethods(program, selectedSourceFiles);
   const recursiveIds = recursiveMethodIds(methods);
-  const methodsByFile = new Map<string, MethodDescriptor[]>();
-  for (const method of methods) {
-    const descriptors = methodsByFile.get(method.filePath) ?? [];
-    descriptors.push({
-      functionName: method.functionName,
-      containerName: method.containerName,
-      displayName: method.displayName,
-      startLine: method.startLine,
-      endLine: method.endLine,
-      bodySpan: method.bodySpan,
-      cognitiveComplexity: method.baseCognitiveComplexity + (recursiveIds.has(method.id) ? 1 : 0)
-    });
-    methodsByFile.set(method.filePath, descriptors);
-  }
-
-  return resolvedFiles.map((filePath) => ({
-    filePath,
-    methods: sortDescriptors(methodsByFile.get(filePath) ?? [])
-  }));
+  return buildParsedFileMethods(resolvedFiles, methods, recursiveIds);
 }
 
 function recursiveMethodIds(methods: InternalMethod[]): Set<string> {
@@ -174,41 +126,11 @@ function stronglyConnectedRecursiveMembers(
     stack.push(node);
     onStack.add(node);
 
-    for (const target of edges.get(node) ?? []) {
-      if (!methodsById.has(target)) {
-        continue;
-      }
-      if (!indexByNode.has(target)) {
-        strongConnect(target);
-        lowLinkByNode.set(node, Math.min(lowLinkByNode.get(node)!, lowLinkByNode.get(target)!));
-      } else if (onStack.has(target)) {
-        lowLinkByNode.set(node, Math.min(lowLinkByNode.get(node)!, indexByNode.get(target)!));
-      }
-    }
-
-    if (lowLinkByNode.get(node) !== indexByNode.get(node)) {
+    visitRecursiveTargets(node, edges, methodsById, strongConnect, indexByNode, lowLinkByNode, onStack);
+    if (!isComponentRoot(node, indexByNode, lowLinkByNode)) {
       return;
     }
-
-    const component: string[] = [];
-    let member = "";
-    do {
-      member = stack.pop()!;
-      onStack.delete(member);
-      component.push(member);
-    } while (member !== node);
-
-    if (component.length > 1) {
-      component.forEach((componentMember) => {
-        recursiveMembers.add(componentMember);
-      });
-      return;
-    }
-
-    const singleton = component[0];
-    if (edges.get(singleton)?.has(singleton)) {
-      recursiveMembers.add(singleton);
-    }
+    markRecursiveComponent(popComponent(node, stack, onStack), edges, recursiveMembers);
   };
 
   for (const node of edges.keys()) {
@@ -249,6 +171,157 @@ function nameKey(name: string, arity: number): string {
 
 function ownerAndNameKey(ownerName: string, name: string, arity: number): string {
   return `${ownerName}:${name}:${arity}`;
+}
+
+function createTypeScriptProgram(rootNames: string[]): ts.Program {
+  return ts.createProgram({
+    rootNames,
+    options: {
+      allowJs: false,
+      checkJs: false,
+      jsx: ts.JsxEmit.Preserve,
+      module: ts.ModuleKind.Node16,
+      moduleResolution: ts.ModuleResolutionKind.Node16,
+      noEmit: true,
+      resolveJsonModule: true,
+      skipLibCheck: true,
+      target: ts.ScriptTarget.ES2022
+    }
+  });
+}
+
+function selectProgramSourceFiles(program: ts.Program, selectedFiles: Set<string>): ts.SourceFile[] {
+  return program.getSourceFiles().filter((sourceFile) => selectedFiles.has(normalizeFilePath(sourceFile.fileName)));
+}
+
+function ensureSelectedFilesParse(program: ts.Program, sourceFiles: ts.SourceFile[]): void {
+  for (const sourceFile of sourceFiles) {
+    const diagnostics = program.getSyntacticDiagnostics(sourceFile);
+    if (diagnostics.length > 0) {
+      throw new Error(formatDiagnostics(diagnostics));
+    }
+  }
+}
+
+function collectSelectedMethods(program: ts.Program, sourceFiles: ts.SourceFile[]): InternalMethod[] {
+  const checker = program.getTypeChecker();
+  const methods: InternalMethod[] = [];
+  for (const sourceFile of sourceFiles) {
+    methods.push(...collectMethodsFromSourceFile(sourceFile, checker));
+  }
+  return methods;
+}
+
+function buildParsedFileMethods(
+  resolvedFiles: string[],
+  methods: InternalMethod[],
+  recursiveIds: Set<string>
+): ParsedFileMethods[] {
+  const methodsByFile = new Map<string, MethodDescriptor[]>();
+  for (const method of methods) {
+    const descriptors = methodsByFile.get(method.filePath) ?? [];
+    descriptors.push(toMethodDescriptor(method, recursiveIds));
+    methodsByFile.set(method.filePath, descriptors);
+  }
+  return resolvedFiles.map((filePath) => ({
+    filePath,
+    methods: sortDescriptors(methodsByFile.get(filePath) ?? [])
+  }));
+}
+
+function toMethodDescriptor(method: InternalMethod, recursiveIds: Set<string>): MethodDescriptor {
+  return {
+    functionName: method.functionName,
+    containerName: method.containerName,
+    displayName: method.displayName,
+    startLine: method.startLine,
+    endLine: method.endLine,
+    bodySpan: method.bodySpan,
+    cognitiveComplexity: method.baseCognitiveComplexity + (recursiveIds.has(method.id) ? 1 : 0)
+  };
+}
+
+function visitRecursiveTargets(
+  node: string,
+  edges: Map<string, Set<string>>,
+  methodsById: Map<string, InternalMethod>,
+  strongConnect: (node: string) => void,
+  indexByNode: Map<string, number>,
+  lowLinkByNode: Map<string, number>,
+  onStack: Set<string>
+): void {
+  for (const target of edges.get(node) ?? []) {
+    if (!methodsById.has(target)) {
+      continue;
+    }
+    if (visitUnseenTarget(node, target, strongConnect, indexByNode, lowLinkByNode)) {
+      continue;
+    }
+    updateLowLinkFromStackTarget(node, target, indexByNode, lowLinkByNode, onStack);
+  }
+}
+
+function visitUnseenTarget(
+  node: string,
+  target: string,
+  strongConnect: (node: string) => void,
+  indexByNode: Map<string, number>,
+  lowLinkByNode: Map<string, number>
+): boolean {
+  if (indexByNode.has(target)) {
+    return false;
+  }
+  strongConnect(target);
+  lowLinkByNode.set(node, Math.min(lowLinkByNode.get(node)!, lowLinkByNode.get(target)!));
+  return true;
+}
+
+function updateLowLinkFromStackTarget(
+  node: string,
+  target: string,
+  indexByNode: Map<string, number>,
+  lowLinkByNode: Map<string, number>,
+  onStack: Set<string>
+): void {
+  if (!onStack.has(target)) {
+    return;
+  }
+  lowLinkByNode.set(node, Math.min(lowLinkByNode.get(node)!, indexByNode.get(target)!));
+}
+
+function isComponentRoot(
+  node: string,
+  indexByNode: Map<string, number>,
+  lowLinkByNode: Map<string, number>
+): boolean {
+  return lowLinkByNode.get(node) === indexByNode.get(node);
+}
+
+function popComponent(node: string, stack: string[], onStack: Set<string>): string[] {
+  const component: string[] = [];
+  let member = "";
+  do {
+    member = stack.pop()!;
+    onStack.delete(member);
+    component.push(member);
+  } while (member !== node);
+  return component;
+}
+
+function markRecursiveComponent(
+  component: string[],
+  edges: Map<string, Set<string>>,
+  recursiveMembers: Set<string>
+): void {
+  if (component.length > 1) {
+    component.forEach((member) => {
+      recursiveMembers.add(member);
+    });
+    return;
+  }
+  if (edges.get(component[0])?.has(component[0])) {
+    recursiveMembers.add(component[0]);
+  }
 }
 
 function formatDiagnostics(diagnostics: readonly ts.Diagnostic[]): string {

--- a/vitest.crap.config.ts
+++ b/vitest.crap.config.ts
@@ -1,0 +1,10 @@
+import { withCrapTypescriptVitest } from "@barney-media/crap-typescript-vitest";
+
+import baseConfig from "./vitest.config";
+
+export default withCrapTypescriptVitest(baseConfig, {
+  changedOnly: false,
+  packageManager: "npm",
+  paths: ["packages"],
+  projectRoot: process.cwd()
+});


### PR DESCRIPTION
## Summary
- add an always-on `crap-typescript Gate` workflow job alongside the existing cognitive gate
- wire the repo to the published `@barney-media/crap-typescript-vitest` package with a dedicated Vitest config and local check script
- refactor core parser/discovery/CLI helpers so the repository passes the published CRAP threshold and keep the docs in sync

## Verification
- npm test
- npm run cognitive-typescript-check
- npm run crap-typescript-check
- npm pack --workspaces

Closes #2