### PR TITLE
Reduce cognitive complexity threshold to 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `cognitive-typescript` is a shared Cognitive Complexity toolkit for TypeScript projects.
 
-It performs pure static analysis using the Sonar Cognitive Complexity white paper as the metric source of truth, reports the worst function-like bodies first, and fails when any analyzed function exceeds the fixed threshold of `25`.
+It performs pure static analysis using the Sonar Cognitive Complexity white paper as the metric source of truth, reports the worst function-like bodies first, and fails when any analyzed function exceeds the fixed threshold of `15`.
 
 ## Modules
 
@@ -16,7 +16,7 @@ It performs pure static analysis using the Sonar Cognitive Complexity white pape
 - The implementation follows the SonarSource Cognitive Complexity white paper.
 - It is pure static analysis.
 - It does not read coverage reports or execute tests as part of the analysis itself.
-- The threshold is fixed at `25`.
+- The threshold is fixed at `15`.
 
 ## Build and Test
 
@@ -74,7 +74,7 @@ npx cognitive-typescript
 
 - `0` success, threshold respected
 - `1` invalid CLI usage or execution failure
-- `2` Cognitive Complexity threshold exceeded (`> 25`)
+- `2` Cognitive Complexity threshold exceeded (`> 15`)
 
 ## Compatibility Matrix
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,7 +31,7 @@ npx cognitive-typescript packages/api packages/web
 
 - `0` success, threshold respected
 - `1` invalid CLI usage or execution failure
-- `2` Cognitive Complexity threshold exceeded (`> 25`)
+- `2` Cognitive Complexity threshold exceeded (`> 15`)
 
 See the [main repository](https://github.com/fabian-barney/cognitive-typescript) for full details.
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,4 +1,4 @@
-export const COGNITIVE_COMPLEXITY_THRESHOLD = 25;
+export const COGNITIVE_COMPLEXITY_THRESHOLD = 15;
 export const NO_FILES_MESSAGE = "No TypeScript files to analyze.";
 export const NO_ANALYZABLE_FUNCTIONS_MESSAGE = "No function-like bodies to analyze.";
 

--- a/packages/core/test/analysis.test.ts
+++ b/packages/core/test/analysis.test.ts
@@ -42,7 +42,7 @@ export function second(flag: boolean): number {
     expect(result.thresholdExceeded).toBe(false);
   });
 
-  it("reports threshold failures when any function exceeds 25", async () => {
+  it("reports threshold failures when any function exceeds 15", async () => {
     const projectRoot = await createTempDir("cognitive-analysis-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -46,7 +46,7 @@ describe("cli", () => {
 
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toContain("tooComplex");
-    expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded: 28 > 25");
+    expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded: 28 > 15");
   });
 });
 

--- a/spec.md
+++ b/spec.md
@@ -10,7 +10,7 @@ It shall:
 - parse function-like bodies with the TypeScript compiler API
 - compute Cognitive Complexity using the Sonar white-paper rules, with TypeScript-specific derivations
 - report the worst functions first
-- fail when any analyzed function exceeds the fixed threshold of `25`
+- fail when any analyzed function exceeds the fixed threshold of `15`
 
 ## 2. Scope
 
@@ -200,11 +200,11 @@ If files are selected but no function-like bodies are analyzable:
 
 ## 10. Threshold
 
-The fixed threshold shall be `25`.
+The fixed threshold shall be `15`.
 
-If the maximum Cognitive Complexity exceeds `25`:
+If the maximum Cognitive Complexity exceeds `15`:
 
-- the CLI shall print `Cognitive Complexity threshold exceeded: <max> > 25` to stderr
+- the CLI shall print `Cognitive Complexity threshold exceeded: <max> > 15` to stderr
 - the CLI shall exit with code `2`
 
 Otherwise the CLI shall exit with code `0`.


### PR DESCRIPTION
## Summary
- lower the fixed cognitive complexity threshold from 25 to 15
- update threshold-specific core test assertions
- align the repository docs and specification with the new limit

## Testing
- npm test