### PR TITLE
Bump crap-typescript to v0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@barney-media/crap-typescript-vitest": "^0.2.1",
+        "@barney-media/crap-typescript-vitest": "^0.2.2",
         "@types/node": "^25.5.1",
         "@vitest/coverage-v8": "^4.1.2",
         "jest": "^30.3.0",
@@ -503,9 +503,9 @@
       "link": true
     },
     "node_modules/@barney-media/crap-typescript-core": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-core/-/crap-typescript-core-0.2.1.tgz",
-      "integrity": "sha512-QMAvgB1Nsk+XkVZsFQn4ttP6uaSbLSJPgFvJeVLG/r5DGg7ZthQOZL0+Fm6MEJsmwJ8PE2S0Ud8qHtdAv2s3mQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-core/-/crap-typescript-core-0.2.2.tgz",
+      "integrity": "sha512-x+BUxUxWvC327k3lUI9dsxqC44FJ+GwnZrxZxXSvMCOJtNSlNX6MPiqVVIDMDUGGlTjCvpCsdnY9fxhAIBAetQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -516,13 +516,13 @@
       }
     },
     "node_modules/@barney-media/crap-typescript-vitest": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-vitest/-/crap-typescript-vitest-0.2.1.tgz",
-      "integrity": "sha512-6+6EIMDVZ7itJUae9gKjbkMmiaA6f1iv5wnoujmNzpSiwPQBj7LyxiJaQtb5iU/kdMgp0Xxx9p3Wj8++07NdzQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-vitest/-/crap-typescript-vitest-0.2.2.tgz",
+      "integrity": "sha512-MCbzWnCes5MWhul7nOIPgRQzPTewLPB5VhP5tmOJs4HtWBwXR6uk5ab0Vp8fbas8E7VeWFdWAfABbH2cdAyPuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.2.1"
+        "@barney-media/crap-typescript-core": "^0.2.2"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "verify-release-version": "node ./scripts/verify-release-version.mjs"
   },
   "devDependencies": {
-    "@barney-media/crap-typescript-vitest": "^0.2.1",
+    "@barney-media/crap-typescript-vitest": "^0.2.2",
     "@types/node": "^25.5.1",
     "@vitest/coverage-v8": "^4.1.2",
     "jest": "^30.3.0",

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -54,32 +54,14 @@ export async function runCli(
     return parsed;
   }
   if (parsed.mode === "help") {
-    writeLine(stdout, usage());
-    return 0;
+    return writeHelp(stdout);
   }
 
   const result = await analyzeCliProject(parsed, projectRoot, stderr);
   if (!result) {
     return 1;
   }
-  if (result.selectedFiles.length === 0) {
-    writeLine(stdout, NO_FILES_MESSAGE);
-    return 0;
-  }
-  if (result.metrics.length === 0) {
-    writeLine(stdout, NO_ANALYZABLE_FUNCTIONS_MESSAGE);
-    return 0;
-  }
-
-  writeLine(stdout, formatReport(result.metrics));
-  if (!result.thresholdExceeded) {
-    return 0;
-  }
-  writeLine(
-    stderr,
-    `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${COGNITIVE_COMPLEXITY_THRESHOLD}`
-  );
-  return 2;
+  return handleCliResult(result, stdout, stderr);
 }
 
 function parseCliInputs(args: string[], stdout: Writer, stderr: Writer): CliArguments | number {
@@ -107,6 +89,47 @@ async function analyzeCliProject(
     writeLine(stderr, (error as Error).message);
     return null;
   }
+}
+
+function writeHelp(stdout: Writer): number {
+  writeLine(stdout, usage());
+  return 0;
+}
+
+function handleCliResult(
+  result: Awaited<ReturnType<typeof analyzeProject>>,
+  stdout: Writer,
+  stderr: Writer
+): number {
+  const earlyExit = resolveCliEarlyExit(result, stdout);
+  if (earlyExit !== null) {
+    return earlyExit;
+  }
+  writeLine(stdout, formatReport(result.metrics));
+  return writeThresholdStatus(result, stderr);
+}
+
+function resolveCliEarlyExit(result: Awaited<ReturnType<typeof analyzeProject>>, stdout: Writer): number | null {
+  if (result.selectedFiles.length === 0) {
+    writeLine(stdout, NO_FILES_MESSAGE);
+    return 0;
+  }
+  if (result.metrics.length === 0) {
+    writeLine(stdout, NO_ANALYZABLE_FUNCTIONS_MESSAGE);
+    return 0;
+  }
+  return null;
+}
+
+function writeThresholdStatus(result: Awaited<ReturnType<typeof analyzeProject>>, stderr: Writer): number {
+  if (!result.thresholdExceeded) {
+    return 0;
+  }
+  writeLine(
+    stderr,
+    `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${COGNITIVE_COMPLEXITY_THRESHOLD}`
+  );
+  return 2;
 }
 
 interface CliParseState {

--- a/packages/core/src/cognitiveComplexity.ts
+++ b/packages/core/src/cognitiveComplexity.ts
@@ -295,28 +295,45 @@ function fallbackCallTarget(
   sourceFile: ts.SourceFile,
   containerName: string | null
 ): Pick<CallTarget, "name" | "ownerName"> {
-  if (ts.isIdentifier(expression)) {
-    return {
-      name: expression.text,
-      ownerName: null
-    };
-  }
-  if (ts.isPropertyAccessExpression(expression)) {
-    return {
-      name: expression.name.text,
-      ownerName: ownerText(expression.expression, sourceFile, containerName)
-    };
-  }
-  if (ts.isElementAccessExpression(expression) && expression.argumentExpression) {
-    return {
-      name: `[${expression.argumentExpression.getText(sourceFile)}]`,
-      ownerName: ownerText(expression.expression, sourceFile, containerName)
-    };
-  }
-  return {
-    name: null,
-    ownerName: null
-  };
+  return resolveIdentifierCallTarget(expression)
+    ?? resolvePropertyAccessCallTarget(expression, sourceFile, containerName)
+    ?? resolveElementAccessCallTarget(expression, sourceFile, containerName)
+    ?? { name: null, ownerName: null };
+}
+
+function resolveIdentifierCallTarget(expression: ts.Expression): Pick<CallTarget, "name" | "ownerName"> | null {
+  return ts.isIdentifier(expression)
+    ? {
+        name: expression.text,
+        ownerName: null
+      }
+    : null;
+}
+
+function resolvePropertyAccessCallTarget(
+  expression: ts.Expression,
+  sourceFile: ts.SourceFile,
+  containerName: string | null
+): Pick<CallTarget, "name" | "ownerName"> | null {
+  return ts.isPropertyAccessExpression(expression)
+    ? {
+        name: expression.name.text,
+        ownerName: ownerText(expression.expression, sourceFile, containerName)
+      }
+    : null;
+}
+
+function resolveElementAccessCallTarget(
+  expression: ts.Expression,
+  sourceFile: ts.SourceFile,
+  containerName: string | null
+): Pick<CallTarget, "name" | "ownerName"> | null {
+  return ts.isElementAccessExpression(expression) && expression.argumentExpression
+    ? {
+        name: `[${expression.argumentExpression.getText(sourceFile)}]`,
+        ownerName: ownerText(expression.expression, sourceFile, containerName)
+      }
+    : null;
 }
 
 function ownerText(expression: ts.Expression, sourceFile: ts.SourceFile, containerName: string | null): string | null {

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -167,16 +167,31 @@ async function walkSourceTree(
   for (const entry of entries) {
     const absolutePath = path.join(currentDir, entry.name);
     if (entry.isDirectory()) {
-      if (IGNORED_DIRECTORIES.has(entry.name)) {
-        continue;
-      }
-      await walkSourceTree(absolutePath, onFile);
+      await walkDirectoryEntry(entry.name, absolutePath, onFile);
       continue;
     }
-    if (entry.isFile() && isAnalyzableFile(absolutePath)) {
-      await onFile(absolutePath);
+    if (entry.isFile()) {
+      await walkFileEntry(absolutePath, onFile);
     }
   }
+}
+
+async function walkDirectoryEntry(
+  entryName: string,
+  absolutePath: string,
+  onFile: (filePath: string) => Promise<void>
+): Promise<void> {
+  if (IGNORED_DIRECTORIES.has(entryName)) {
+    return;
+  }
+  await walkSourceTree(absolutePath, onFile);
+}
+
+async function walkFileEntry(absolutePath: string, onFile: (filePath: string) => Promise<void>): Promise<void> {
+  if (!isAnalyzableFile(absolutePath)) {
+    return;
+  }
+  await onFile(absolutePath);
 }
 
 async function expandDirectoryPath(directoryPath: string, files: Set<string>): Promise<void> {

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -72,40 +72,50 @@ function resolveCallTargets(
   methodsByName: Map<string, Set<string>>,
   methodsByOwnerAndName: Map<string, Set<string>>
 ): Set<string> {
-  if (call.symbol) {
-    const direct = methodsBySymbol.get(call.symbol);
-    if (direct) {
-      return direct;
-    }
-  }
+  return resolveDirectCallTargets(call, methodsBySymbol)
+    ?? resolveOwnerCallTargets(call, methodsByOwnerAndName)
+    ?? resolveNamedCallTargets(call, method, methodsByName)
+    ?? new Set();
+}
 
-  if (call.name && call.ownerName) {
-    const ownerMatches = methodsByOwnerAndName.get(ownerAndNameKey(call.ownerName, call.name, call.arity));
-    if (ownerMatches?.size) {
-      return ownerMatches;
-    }
-  }
+function resolveDirectCallTargets(
+  call: InternalMethod["calls"][number],
+  methodsBySymbol: Map<ts.Symbol, Set<string>>
+): Set<string> | null {
+  return call.symbol ? methodsBySymbol.get(call.symbol) ?? null : null;
+}
 
+function resolveOwnerCallTargets(
+  call: InternalMethod["calls"][number],
+  methodsByOwnerAndName: Map<string, Set<string>>
+): Set<string> | null {
+  if (!(call.name && call.ownerName)) {
+    return null;
+  }
+  const ownerMatches = methodsByOwnerAndName.get(ownerAndNameKey(call.ownerName, call.name, call.arity));
+  return ownerMatches?.size ? ownerMatches : null;
+}
+
+function resolveNamedCallTargets(
+  call: InternalMethod["calls"][number],
+  method: InternalMethod,
+  methodsByName: Map<string, Set<string>>
+): Set<string> | null {
   if (!call.name) {
-    return new Set();
+    return null;
   }
+  return selectNamedCallTargets(methodsByName.get(nameKey(call.name, call.arity)), method.id);
+}
 
-  const selfMatches = new Set<string>();
-  for (const candidate of methodsByName.get(nameKey(call.name, call.arity)) ?? []) {
-    if (candidate === method.id) {
-      selfMatches.add(candidate);
-    }
+function selectNamedCallTargets(globalMatches: Set<string> | undefined, methodId: string): Set<string> | null {
+  if (globalMatches?.has(methodId)) {
+    return new Set([methodId]);
   }
-  if (selfMatches.size > 0) {
-    return selfMatches;
-  }
+  return selectSingleNamedCallTarget(globalMatches);
+}
 
-  const globalMatches = methodsByName.get(nameKey(call.name, call.arity));
-  if (globalMatches?.size === 1) {
-    return globalMatches;
-  }
-
-  return new Set();
+function selectSingleNamedCallTarget(globalMatches: Set<string> | undefined): Set<string> | null {
+  return globalMatches?.size === 1 ? globalMatches : null;
 }
 
 function stronglyConnectedRecursiveMembers(
@@ -250,15 +260,29 @@ function visitRecursiveTargets(
   lowLinkByNode: Map<string, number>,
   onStack: Set<string>
 ): void {
-  for (const target of edges.get(node) ?? []) {
-    if (!methodsById.has(target)) {
-      continue;
-    }
-    if (visitUnseenTarget(node, target, strongConnect, indexByNode, lowLinkByNode)) {
-      continue;
-    }
-    updateLowLinkFromStackTarget(node, target, indexByNode, lowLinkByNode, onStack);
+  const targets = edges.get(node);
+  if (!targets) {
+    return;
   }
+  for (const target of targets) {
+    if (methodsById.has(target)) {
+      visitResolvedTarget(node, target, strongConnect, indexByNode, lowLinkByNode, onStack);
+    }
+  }
+}
+
+function visitResolvedTarget(
+  node: string,
+  target: string,
+  strongConnect: (node: string) => void,
+  indexByNode: Map<string, number>,
+  lowLinkByNode: Map<string, number>,
+  onStack: Set<string>
+): void {
+  if (visitUnseenTarget(node, target, strongConnect, indexByNode, lowLinkByNode)) {
+    return;
+  }
+  updateLowLinkFromStackTarget(node, target, indexByNode, lowLinkByNode, onStack);
 }
 
 function visitUnseenTarget(

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -32,6 +32,28 @@ describe("cli", () => {
     expect(stderr.toString()).toBe("");
   });
 
+  it("prints usage and returns 0 for --help", async () => {
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+
+    const exitCode = await runCli(["--help"], process.cwd(), stdout, stderr);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.toString()).toContain("Usage:");
+    expect(stderr.toString()).toBe("");
+  });
+
+  it("prints the parse error and usage for invalid arguments", async () => {
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+
+    const exitCode = await runCli(["--changed", "src"], process.cwd(), stdout, stderr);
+
+    expect(exitCode).toBe(1);
+    expect(stdout.toString()).toContain("Usage:");
+    expect(stderr.toString()).toContain("--changed cannot be combined with file arguments");
+  });
+
   it("returns exit code 2 when the threshold is exceeded", async () => {
     const projectRoot = await createTempDir("cognitive-cli-");
     tempDirs.push(projectRoot);

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -105,6 +105,36 @@ export default function () {
       'registry["upper"]': 1
     });
   });
+
+  it("marks identifier and element-access self calls as recursive", async () => {
+    const projectRoot = await createTempDir("cognitive-parser-");
+    tempDirs.push(projectRoot);
+    const filePath = path.join(projectRoot, "sample.ts");
+    await writeProjectFiles(projectRoot, {
+      "sample.ts": `export function recurse(flag: boolean): number {
+  if (flag) {
+    return recurse(false);
+  }
+  return 0;
+}
+
+export const registry = {
+  ["recurse"](flag: boolean): number {
+    if (flag) {
+      return registry["recurse"](false);
+    }
+    return 0;
+  }
+};
+`
+    });
+
+    const methods = await parseFileMethods(filePath);
+    expect(toComplexityMap(methods)).toEqual({
+      recurse: 2,
+      'registry["recurse"]': 2
+    });
+  });
 });
 
 function toComplexityMap(methods: Awaited<ReturnType<typeof parseFileMethods>>): Record<string, number> {


### PR DESCRIPTION
## Summary
- bump `@barney-media/crap-typescript-vitest` to `^0.2.2`
- refresh the lockfile to the published `0.2.2` release
- adjust core helpers and tests so the stricter CRAP attribution in `0.2.2` passes the repo gate

## Testing
- npm test
- npm run crap-typescript-check