### PR TITLE
#6 prepare v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,37 +36,39 @@ jobs:
       - name: Verify release versions
         run: npm run verify-release-version
 
+      - name: Render release notes
+        run: node ./scripts/render-release-notes.mjs "${GITHUB_REF_NAME}" > release-notes.md
+
       - name: Run build and tests
         run: npm test
 
-      # Trusted Publishing uses the job OIDC token for auth and npm
-      # automatically emits provenance for public packages from public repos.
+      # Bootstrap the first public release with NPM_TOKEN auth and OIDC
+      # provenance, then switch this same workflow file to pure Trusted
+      # Publishing after the packages exist on npmjs.com.
       - name: Publish core
-        run: npm publish --workspace packages/core --access public
+        run: npm publish --workspace packages/core --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish CLI
-        run: npm publish --workspace packages/cli --access public
+        run: npm publish --workspace packages/cli --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Vitest adapter
-        run: npm publish --workspace packages/vitest --access public
+        run: npm publish --workspace packages/vitest --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Jest adapter
-        run: npm publish --workspace packages/jest --access public
+        run: npm publish --workspace packages/jest --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          version="${GITHUB_REF_NAME#v}"
-          cat > release-notes.md <<EOF
-          ## Packages
-
-          - \`@barney-media/cognitive-typescript-core@${version}\`
-          - \`@barney-media/cognitive-typescript@${version}\`
-          - \`@barney-media/cognitive-typescript-vitest@${version}\`
-          - \`@barney-media/cognitive-typescript-jest@${version}\`
-          EOF
-
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
             gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+
+- No unreleased changes.
+
+## [0.1.0] - 2026-04-10
+
+### Added
+
+- Published the initial `@barney-media` package set for the CLI, core library, and Vitest and Jest adapters.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ npx cognitive-typescript
 
 Verified and unverified syntax shapes are tracked in [docs/compatibility-matrix.md](docs/compatibility-matrix.md). The matrix is backed by fixtures under `tests/fixtures/compatibility-matrix/`.
 
+## Release
+
+`v0.1.0` is the one-time bootstrap release for the public npm packages. The tag-triggered release workflow uses the GitHub repo `NPM_TOKEN` secret for npm authentication and `--provenance` for supply-chain attestation, while rendering the GitHub release notes from `CHANGELOG.md`.
+
+After `v0.1.0` is published successfully, configure npm Trusted Publishers manually for these packages against `fabian-barney/cognitive-typescript` and `.github/workflows/release.yml`:
+
+- `@barney-media/cognitive-typescript-core`
+- `@barney-media/cognitive-typescript`
+- `@barney-media/cognitive-typescript-vitest`
+- `@barney-media/cognitive-typescript-jest`
+
+The first pure Trusted Publisher release should then be cut as `v0.1.1` by removing `NPM_TOKEN` usage from the workflow while keeping the same workflow filename and `id-token: write` permission. After `v0.1.1` publishes successfully, remove the GitHub repo `NPM_TOKEN` secret.
+
+Release notes can be rendered locally with:
+
+```bash
+npm run render-release-notes -- v0.1.0
+```
+
 ## Contributing
 
 See `CONTRIBUTING.md` for the issue-linked branch, commit, and pull-request flow used in this repository.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "crap-typescript-check": "npm run build && vitest run --config vitest.crap.config.ts",
     "test": "npm run build && vitest run",
     "pack": "npm pack --workspaces",
+    "render-release-notes": "node ./scripts/render-release-notes.mjs",
     "verify-release-version": "node ./scripts/verify-release-version.mjs"
   },
   "devDependencies": {

--- a/scripts/render-release-notes.mjs
+++ b/scripts/render-release-notes.mjs
@@ -1,0 +1,33 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const tagRef = process.env.GITHUB_REF_NAME ?? process.argv[2];
+if (!tagRef) {
+  throw new Error("A tag name is required.");
+}
+
+const expectedVersion = tagRef.startsWith("v") ? tagRef.slice(1) : tagRef;
+const changelog = await readFile(path.resolve("CHANGELOG.md"), "utf8");
+const lines = changelog.replace(/\r\n/g, "\n").split("\n");
+const sectionHeader = `## [${expectedVersion}]`;
+const startIndex = lines.findIndex((line) => line.startsWith(sectionHeader));
+
+if (startIndex === -1) {
+  throw new Error(`CHANGELOG.md does not contain a section for ${expectedVersion}.`);
+}
+
+const sectionLines = [];
+for (let index = startIndex + 1; index < lines.length; index += 1) {
+  const line = lines[index];
+  if (line.startsWith("## [")) {
+    break;
+  }
+  sectionLines.push(line);
+}
+
+const releaseNotes = sectionLines.join("\n").trim();
+if (!releaseNotes) {
+  throw new Error(`CHANGELOG.md section ${expectedVersion} is empty.`);
+}
+
+process.stdout.write(`${releaseNotes}\n`);


### PR DESCRIPTION
Closes #6

## Summary

- add `CHANGELOG.md` and changelog-based GitHub release note rendering
- switch the release workflow to the one-time `v0.1.0` bootstrap mode using `NPM_TOKEN` plus provenance
- document the manual Trusted Publisher setup needed before the follow-up `v0.1.1` release

## Test plan

- [x] `npm test`
- [x] `npm run verify-release-version -- v0.1.0`
- [x] `npm pack --workspace packages/cli --dry-run --json`
- [x] `npm pack --workspace packages/core --dry-run --json`
- [x] `node ./scripts/render-release-notes.mjs v0.1.0`