### PR TITLE
#6 switch to pure Trusted Publishing and bump to v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,28 +42,19 @@ jobs:
       - name: Run build and tests
         run: npm test
 
-      # Bootstrap the first public release with NPM_TOKEN auth and OIDC
-      # provenance, then switch this same workflow file to pure Trusted
-      # Publishing after the packages exist on npmjs.com.
+      # Trusted Publishing uses the job OIDC token for auth and npm
+      # automatically emits provenance for public packages from public repos.
       - name: Publish core
-        run: npm publish --workspace packages/core --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace packages/core --access public
 
       - name: Publish CLI
-        run: npm publish --workspace packages/cli --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace packages/cli --access public
 
       - name: Publish Vitest adapter
-        run: npm publish --workspace packages/vitest --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace packages/vitest --access public
 
       - name: Publish Jest adapter
-        run: npm publish --workspace packages/jest --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace packages/jest --access public
 
       - name: Create GitHub release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - No unreleased changes.
 
+## [0.1.1] - 2026-04-10
+
+### Changed
+
+- Switched npm publishing to pure Trusted Publishing.
+- Removed token-based publish configuration after npm Trusted Publisher setup.
+
 ## [0.1.0] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,21 +82,21 @@ Verified and unverified syntax shapes are tracked in [docs/compatibility-matrix.
 
 ## Release
 
-`v0.1.0` is the one-time bootstrap release for the public npm packages. The tag-triggered release workflow uses the GitHub repo `NPM_TOKEN` secret for npm authentication and `--provenance` for supply-chain attestation, while rendering the GitHub release notes from `CHANGELOG.md`.
+The default release path uses npm Trusted Publishing from `.github/workflows/release.yml`. Tag `v<version>` from `main` after the build workflow is green. The tag-triggered release workflow verifies package versions, renders the GitHub release notes from `CHANGELOG.md`, publishes the four public npm packages, and creates the GitHub release.
 
-After `v0.1.0` is published successfully, configure npm Trusted Publishers manually for these packages against `fabian-barney/cognitive-typescript` and `.github/workflows/release.yml`:
+`v0.1.0` was the one-time bootstrap release that used the GitHub repo `NPM_TOKEN` secret together with provenance so the package names could be created on npm. Trusted Publishers are now the default for these packages:
 
 - `@barney-media/cognitive-typescript-core`
 - `@barney-media/cognitive-typescript`
 - `@barney-media/cognitive-typescript-vitest`
 - `@barney-media/cognitive-typescript-jest`
 
-The first pure Trusted Publisher release should then be cut as `v0.1.1` by removing `NPM_TOKEN` usage from the workflow while keeping the same workflow filename and `id-token: write` permission. After `v0.1.1` publishes successfully, remove the GitHub repo `NPM_TOKEN` secret.
+After `v0.1.1` publishes successfully via Trusted Publishing, remove the GitHub repo `NPM_TOKEN` secret.
 
 Release notes can be rendered locally with:
 
 ```bash
-npm run render-release-notes -- v0.1.0
+npm run render-release-notes -- v0.1.1
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cognitive-typescript-parent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cognitive-typescript-parent",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5401,10 +5401,10 @@
     },
     "packages/cli": {
       "name": "@barney-media/cognitive-typescript",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.1.0"
+        "@barney-media/cognitive-typescript-core": "^0.1.1"
       },
       "bin": {
         "cognitive-typescript": "dist/bin.js"
@@ -5415,7 +5415,7 @@
     },
     "packages/core": {
       "name": "@barney-media/cognitive-typescript-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "typescript": "^6.0.2"
@@ -5426,10 +5426,10 @@
     },
     "packages/jest": {
       "name": "@barney-media/cognitive-typescript-jest",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.1.0"
+        "@barney-media/cognitive-typescript-core": "^0.1.1"
       },
       "engines": {
         "node": ">=18"
@@ -5440,10 +5440,10 @@
     },
     "packages/vitest": {
       "name": "@barney-media/cognitive-typescript-vitest",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.1.0"
+        "@barney-media/cognitive-typescript-core": "^0.1.1"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cognitive-typescript-parent",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cognitive Complexity metrics for TypeScript",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI for Cognitive Complexity analysis in TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -42,6 +42,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.1.0"
+    "@barney-media/cognitive-typescript-core": "^0.1.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Core Cognitive Complexity analyzer for TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-jest",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Jest integration for cognitive-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -42,7 +42,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.1.0"
+    "@barney-media/cognitive-typescript-core": "^0.1.1"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-vitest",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Vitest integration for cognitive-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -38,7 +38,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.1.0"
+    "@barney-media/cognitive-typescript-core": "^0.1.1"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"


### PR DESCRIPTION
Closes #6

## Summary

- switch the release workflow from token-based bootstrap publishing to pure Trusted Publishing
- bump the repo and all workspace packages from `0.1.0` to `0.1.1`
- document `v0.1.1` as the default release path and record the Trusted Publishing cutover in the changelog

## Test plan

- [x] `npm test`
- [x] `npm run verify-release-version -- v0.1.1`
- [x] `node ./scripts/render-release-notes.mjs v0.1.1`
- [x] `npm pack --dry-run --json` from `packages/cli`
- [x] `npm pack --dry-run --json` from `packages/core`
- [x] `npm pack --dry-run --json` from `packages/vitest`
- [x] `npm pack --dry-run --json` from `packages/jest`

## Release blocker

Do not merge and tag `v0.1.1` until npm Trusted Publishers are configured for all four packages against `.github/workflows/release.yml`.