### PR TITLE
#9 switch cognitive-typescript Gate to published CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "build": "tsc -b packages/core packages/cli packages/vitest packages/jest",
-    "cognitive-typescript-check": "npm run build && vitest run --config vitest.cognitive.config.ts",
+    "cognitive-typescript-check": "node ./scripts/run-cognitive-typescript-gate.mjs packages",
     "crap-typescript-check": "npm run build && vitest run --config vitest.crap.config.ts",
     "test": "npm run build && vitest run",
     "pack": "npm pack --workspaces",

--- a/scripts/run-cognitive-typescript-gate.mjs
+++ b/scripts/run-cognitive-typescript-gate.mjs
@@ -1,0 +1,43 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const targets = process.argv.slice(2);
+
+if (targets.length === 0) {
+  console.error("Usage: node ./scripts/run-cognitive-typescript-gate.mjs <path...>");
+  process.exit(1);
+}
+
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const temporaryDirectory = mkdtempSync(join(tmpdir(), "cognitive-typescript-gate-"));
+
+try {
+  // Run the published CLI outside the repo so local workspaces never shadow npmjs.
+  const result = spawnSync(
+    npmCommand,
+    [
+      "exec",
+      "--yes",
+      "--package=@barney-media/cognitive-typescript@0.1.1",
+      "--",
+      "cognitive-typescript",
+      ...targets.map((target) => resolve(target))
+    ],
+    {
+      cwd: temporaryDirectory,
+      shell: process.platform === "win32",
+      stdio: "inherit"
+    }
+  );
+
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+
+  process.exit(result.status ?? 1);
+} finally {
+  rmSync(temporaryDirectory, { force: true, recursive: true });
+}

--- a/scripts/run-cognitive-typescript-gate.mjs
+++ b/scripts/run-cognitive-typescript-gate.mjs
@@ -10,34 +10,33 @@ if (targets.length === 0) {
   process.exit(1);
 }
 
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const gateArguments = [
+  "exec",
+  "--yes",
+  "--package=@barney-media/cognitive-typescript@0.1.1",
+  "--",
+  "cognitive-typescript",
+  ...targets.map((target) => resolve(target))
+];
+const npmCommand = process.env.npm_execpath ? process.execPath : process.platform === "win32" ? "npm.cmd" : "npm";
+const npmArguments = process.env.npm_execpath ? [process.env.npm_execpath, ...gateArguments] : gateArguments;
 const temporaryDirectory = mkdtempSync(join(tmpdir(), "cognitive-typescript-gate-"));
+let exitCode = 1;
 
 try {
   // Run the published CLI outside the repo so local workspaces never shadow npmjs.
-  const result = spawnSync(
-    npmCommand,
-    [
-      "exec",
-      "--yes",
-      "--package=@barney-media/cognitive-typescript@0.1.1",
-      "--",
-      "cognitive-typescript",
-      ...targets.map((target) => resolve(target))
-    ],
-    {
-      cwd: temporaryDirectory,
-      shell: process.platform === "win32",
-      stdio: "inherit"
-    }
-  );
+  const result = spawnSync(npmCommand, npmArguments, {
+    cwd: temporaryDirectory,
+    stdio: "inherit"
+  });
 
   if (result.error) {
     console.error(result.error.message);
-    process.exit(1);
+  } else {
+    exitCode = result.status ?? 1;
   }
-
-  process.exit(result.status ?? 1);
 } finally {
   rmSync(temporaryDirectory, { force: true, recursive: true });
 }
+
+process.exitCode = exitCode;

--- a/vitest.cognitive.config.ts
+++ b/vitest.cognitive.config.ts
@@ -1,8 +1,0 @@
-import { withCognitiveTypescriptVitest } from "@barney-media/cognitive-typescript-vitest";
-
-import baseConfig from "./vitest.config";
-
-export default withCognitiveTypescriptVitest(baseConfig, {
-  paths: ["packages"],
-  projectRoot: process.cwd()
-});


### PR DESCRIPTION
Refs fabian-barney/cognitive-typescript#9

## Summary
- switch the self-gate to the published `@barney-media/cognitive-typescript@0.1.1` CLI
- add the shared helper that resolves the public CLI from a temporary directory so the repo never self-resolves its workspace package
- remove the obsolete local Vitest cognitive gate config

## Validation
- npm run cognitive-typescript-check
- npm test