### PR TITLE
Bump @barney-media/crap-typescript-vitest to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -541,6 +540,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1717,7 +1737,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -2086,7 +2105,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2978,7 +2996,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -4976,7 +4993,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5088,7 +5104,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5166,7 +5181,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@barney-media/crap-typescript-vitest": "^0.2.3",
+        "@barney-media/crap-typescript-vitest": "^0.3.0",
         "@types/node": "^25.6.2",
         "@vitest/coverage-v8": "^4.1.5",
         "jest": "^30.4.2",
@@ -503,12 +503,14 @@
       "link": true
     },
     "node_modules/@barney-media/crap-typescript-core": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-core/-/crap-typescript-core-0.2.3.tgz",
-      "integrity": "sha512-DMeQXoH9vLSUSfh3RDfvx9r/J7j/9Y/2IhdeAH6l7NtopxWnXngnUBj6WQ9zg5KnamHoTQnRfazR2CIoT/hOng==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-core/-/crap-typescript-core-0.3.0.tgz",
+      "integrity": "sha512-YhyMZYHm0MCHYLJG0lvaXDfqDCcHE6HknDr1fZiEjV0CRmeVCKtuV/L6QEgYjXvYpso7a/yDRuvxYfza66V+vA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@toon-format/toon": "^2.1.0",
+        "fast-xml-parser": "^5.7.2",
         "typescript": "^6.0.2"
       },
       "engines": {
@@ -516,13 +518,13 @@
       }
     },
     "node_modules/@barney-media/crap-typescript-vitest": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-vitest/-/crap-typescript-vitest-0.2.3.tgz",
-      "integrity": "sha512-fpAew37v8tVIesayuSe8PKIRQSfUz4EZMtdbT5lv10fsoufQKEk1ZkZg9ZUHkuvCKZLXwosLhas2EgFV1zs+ZA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@barney-media/crap-typescript-vitest/-/crap-typescript-vitest-0.3.0.tgz",
+      "integrity": "sha512-FCVVWA4eoPWv5cmlRg7lWvk4my24/GtCRWgNeTvuS6oamTiNosIjmup4bUPIAGnJyYYIDTzJG3bgK9YqpY67Ew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.2.3"
+        "@barney-media/crap-typescript-core": "^0.3.0"
       },
       "engines": {
         "node": ">=18"
@@ -539,29 +541,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1002,6 +981,19 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
@@ -1327,6 +1319,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@toon-format/toon": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.2.0.tgz",
+      "integrity": "sha512-FMYqrlZnMN72YIT9KVt7Kxc41gat+RgMIzDmvRRPHw0J7pqW/FeBGDY/4BIWjT71Y+EdI9fCJip90uXuGuYhjw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -2567,6 +2566,45 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4159,6 +4197,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4666,6 +4720,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -5336,6 +5403,22 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "verify-release-version": "node ./scripts/verify-release-version.mjs"
   },
   "devDependencies": {
-    "@barney-media/crap-typescript-vitest": "^0.2.3",
+    "@barney-media/crap-typescript-vitest": "^0.3.0",
     "@types/node": "^25.6.2",
     "@vitest/coverage-v8": "^4.1.5",
     "jest": "^30.4.2",

--- a/vitest.crap.config.ts
+++ b/vitest.crap.config.ts
@@ -4,6 +4,9 @@ import baseConfig from "./vitest.config";
 
 export default withCrapTypescriptVitest(baseConfig, {
   changedOnly: false,
+  failuresOnly: true,
+  format: "text",
+  junit: false,
   packageManager: "npm",
   paths: ["packages"],
   projectRoot: process.cwd()


### PR DESCRIPTION
Closes #15.

## Summary
- bump `@barney-media/crap-typescript-vitest` from `^0.2.3` to `^0.3.0`
- pin the CRAP Vitest adapter to `format: "text"`, `failuresOnly: true`, and `junit: false`
- refresh `package-lock.json` against the released package

## Validation
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces`