### PR TITLE
Align core report controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -542,27 +543,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1005,7 +985,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1737,6 +1716,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -2105,6 +2085,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2589,7 +2570,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
       "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2606,7 +2586,6 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
       "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2996,6 +2975,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -4218,7 +4198,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4742,7 +4721,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
       "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4993,6 +4971,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5104,6 +5083,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5181,6 +5161,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -5423,7 +5404,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5549,6 +5529,7 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "fast-xml-parser": "^5.7.2",
         "typescript": "^6.0.2"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -541,6 +540,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1716,7 +1736,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -2085,7 +2104,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2975,7 +2993,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -4971,7 +4988,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5083,7 +5099,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5161,7 +5176,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -3,4 +3,7 @@ import { runCli } from "@barney-media/cognitive-typescript-core";
 
 void runCli(process.argv.slice(2)).then((exitCode) => {
   process.exitCode = exitCode;
+}).catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 3;
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "fast-xml-parser": "^5.7.2",
     "typescript": "^6.0.2"
   }
 }

--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { COGNITIVE_COMPLEXITY_THRESHOLD } from "./constants";
+import { COGNITIVE_COMPLEXITY_THRESHOLD, validateThreshold } from "./constants";
 import { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots } from "./fileSelection";
 import { analyzeTypeScriptFiles } from "./parser";
 import { toRelativePath } from "./utils";
@@ -8,9 +8,10 @@ import type { AnalysisResult, AnalyzeProjectOptions, MethodMetrics } from "./typ
 
 export async function analyzeProject(options: AnalyzeProjectOptions = {}): Promise<AnalysisResult> {
   const projectRoot = path.resolve(options.projectRoot ?? process.cwd());
+  const threshold = validateThreshold(options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD);
   const selectedFiles = await selectFiles(projectRoot, options.explicitPaths ?? [], options.changedOnly ?? false);
   if (selectedFiles.length === 0) {
-    return emptyAnalysisResult();
+    return emptyAnalysisResult(threshold);
   }
 
   const parsedFiles = await analyzeTypeScriptFiles(selectedFiles);
@@ -31,16 +32,18 @@ export async function analyzeProject(options: AnalyzeProjectOptions = {}): Promi
   return {
     metrics,
     maxCognitiveComplexity,
-    thresholdExceeded: maxCognitiveComplexity > COGNITIVE_COMPLEXITY_THRESHOLD,
+    threshold,
+    thresholdExceeded: maxCognitiveComplexity > threshold,
     selectedFiles,
     warnings: []
   };
 }
 
-function emptyAnalysisResult(): AnalysisResult {
+function emptyAnalysisResult(threshold: number): AnalysisResult {
   return {
     metrics: [],
     maxCognitiveComplexity: 0,
+    threshold,
     thresholdExceeded: false,
     selectedFiles: [],
     warnings: []

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -5,7 +5,7 @@ import { performance } from "node:perf_hooks";
 import { analyzeProject } from "./analyzeProject";
 import { COGNITIVE_COMPLEXITY_THRESHOLD, validateThreshold } from "./constants";
 import { formatAnalysisReport } from "./report";
-import { validateReportPathTargets } from "./reportPaths";
+import { assertInsideProjectRoot, validateReportPathTargets } from "./reportPaths";
 import { writeLine } from "./utils";
 import type { AnalysisCliArguments, CliArguments, ReportFormat, Writer } from "./types";
 
@@ -185,6 +185,7 @@ function ensureOptionIsUnique(seen: boolean, option: string): void {
 }
 
 function finalizeCliArguments(state: ParseState): CliArguments {
+  validateHelpIsStandalone(state);
   if (state.help) {
     return {
       mode: "help",
@@ -222,6 +223,25 @@ function validateCliState(state: ParseState): void {
   }
   if (state.changed && state.fileArgs.length > 0) {
     throw new Error("--changed cannot be combined with file arguments");
+  }
+}
+
+function validateHelpIsStandalone(state: ParseState): void {
+  if (!state.help) {
+    return;
+  }
+  if (
+    state.changedSeen
+    || state.formatSeen
+    || state.thresholdSeen
+    || state.agentSeen
+    || state.failuresOnlySeen
+    || state.omitRedundancySeen
+    || state.outputSeen
+    || state.junitReportSeen
+    || state.fileArgs.length > 0
+  ) {
+    throw new Error("--help cannot be combined with other options or file arguments");
   }
 }
 
@@ -310,12 +330,20 @@ function optionValue(
   if (index + 1 >= args.length) {
     throw new Error(`${option} requires ${valueDescription}`);
   }
-  return args[index + 1];
+  const separatedValue = args[index + 1];
+  if (separatedValue.startsWith("--")) {
+    throw new Error(`${option} requires ${valueDescription}`);
+  }
+  return separatedValue;
 }
 
 function parsePathOption(value: string, option: string): string {
-  if (value.trim() === "") {
+  const trimmedValue = value.trim();
+  if (trimmedValue === "") {
     throw new Error(`${option} requires a path`);
+  }
+  if (trimmedValue !== value) {
+    throw new Error(`${option} must not include leading or trailing whitespace`);
   }
   return value;
 }
@@ -448,17 +476,9 @@ async function validateCliReportPaths(parsed: AnalysisCliArguments, projectRoot:
 
 async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {
   const absolutePath = path.resolve(projectRoot, reportPath);
-  assertInsideProjectRoot(path.resolve(projectRoot), absolutePath);
+  assertInsideProjectRoot(path.resolve(projectRoot), absolutePath, "Report path");
   await mkdir(path.dirname(absolutePath), { recursive: true });
   await writeFile(absolutePath, content);
-}
-
-function assertInsideProjectRoot(projectRoot: string, candidatePath: string): void {
-  const relativePath = path.relative(projectRoot, candidatePath);
-  if (relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))) {
-    return;
-  }
-  throw new Error("Report path must stay inside the project root");
 }
 
 function writeCliThresholdStatus(

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -447,7 +447,6 @@ async function writeCliReports(
 ): Promise<void> {
   const primaryReport = formatAnalysisReport(result.metrics, {
     format: parsed.format,
-    agent: parsed.agent,
     threshold: result.threshold,
     failuresOnly: parsed.failuresOnly,
     omitRedundancy: parsed.omitRedundancy,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -227,22 +227,23 @@ function validateCliState(state: ParseState): void {
 }
 
 function validateHelpIsStandalone(state: ParseState): void {
-  if (!state.help) {
-    return;
-  }
-  if (
-    state.changedSeen
-    || state.formatSeen
-    || state.thresholdSeen
-    || state.agentSeen
-    || state.failuresOnlySeen
-    || state.omitRedundancySeen
-    || state.outputSeen
-    || state.junitReportSeen
-    || state.fileArgs.length > 0
-  ) {
+  if (state.help && hasHelpConflicts(state)) {
     throw new Error("--help cannot be combined with other options or file arguments");
   }
+}
+
+function hasHelpConflicts(state: ParseState): boolean {
+  return [
+    state.changedSeen,
+    state.formatSeen,
+    state.thresholdSeen,
+    state.agentSeen,
+    state.failuresOnlySeen,
+    state.omitRedundancySeen,
+    state.outputSeen,
+    state.junitReportSeen,
+    state.fileArgs.length > 0
+  ].some(Boolean);
 }
 
 function cliMode(state: ParseState): AnalysisCliArguments["mode"] {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -7,7 +7,7 @@ import { COGNITIVE_COMPLEXITY_THRESHOLD, validateThreshold } from "./constants";
 import { formatAnalysisReport } from "./report";
 import { validateReportPathTargets } from "./reportPaths";
 import { writeLine } from "./utils";
-import type { CliArguments, ReportFormat, Writer } from "./types";
+import type { AnalysisCliArguments, CliArguments, ReportFormat, Writer } from "./types";
 
 const REPORT_FORMATS = ["toon", "json", "text", "junit", "none"] as const;
 const REPORT_FORMAT_LIST = REPORT_FORMATS.join(", ");
@@ -110,7 +110,7 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = {
   },
   "--format": (state, args, index, value) => {
     ensureOptionIsUnique(state.formatSeen, "--format");
-    state.format = parseReportFormat(optionValue(args, index, value, "--format", "one of: toon, json, text, junit, none"));
+    state.format = parseReportFormatOption(args, index, value);
     state.formatSeen = true;
     return value === undefined ? index + 1 : index;
   },
@@ -185,12 +185,18 @@ function ensureOptionIsUnique(seen: boolean, option: string): void {
 }
 
 function finalizeCliArguments(state: ParseState): CliArguments {
+  if (state.help) {
+    return {
+      mode: "help",
+      fileArgs: []
+    };
+  }
   applyAgentDefaults(state);
   validateCliState(state);
 
   return {
     mode: cliMode(state),
-    fileArgs: state.help ? [] : state.fileArgs,
+    fileArgs: state.fileArgs,
     format: state.format,
     threshold: state.threshold,
     agent: state.agent,
@@ -219,18 +225,18 @@ function validateCliState(state: ParseState): void {
   }
 }
 
-function cliMode(state: ParseState): CliArguments["mode"] {
-  if (state.help) {
-    return "help";
-  }
+function cliMode(state: ParseState): AnalysisCliArguments["mode"] {
   if (state.changed) {
     return "changed";
   }
   return state.fileArgs.length > 0 ? "explicit" : "all";
 }
 
-function optionalPath<K extends "output" | "junitReport">(key: K, value: string | undefined): Pick<CliArguments, K> | {} {
-  return value === undefined ? {} : { [key]: value } as Pick<CliArguments, K>;
+function optionalPath<K extends "output" | "junitReport">(
+  key: K,
+  value: string | undefined
+): Partial<Pick<AnalysisCliArguments, K>> {
+  return value === undefined ? {} : { [key]: value } as Pick<AnalysisCliArguments, K>;
 }
 
 function parseReportFormat(value: string | undefined): ReportFormat {
@@ -314,13 +320,17 @@ function parsePathOption(value: string, option: string): string {
   return value;
 }
 
+function parseReportFormatOption(args: string[], index: number, inlineValue: string | undefined): ReportFormat {
+  return parseReportFormat(optionValue(args, index, inlineValue, "--format", "a format"));
+}
+
 export async function runCli(
   args: string[],
   projectRoot = process.cwd(),
   stdout: Writer = process.stdout,
   stderr: Writer = process.stderr
 ): Promise<number> {
-  const parsed = parseCliInputs(args, stdout, stderr);
+  const parsed = parseCliInputs(args, stderr);
   if (typeof parsed === "number") {
     return parsed;
   }
@@ -347,18 +357,18 @@ export async function runCli(
   );
 }
 
-function parseCliInputs(args: string[], stdout: Writer, stderr: Writer): CliArguments | number {
+function parseCliInputs(args: string[], stderr: Writer): CliArguments | number {
   try {
     return parseCliArguments(args);
   } catch (error) {
     writeLine(stderr, (error as Error).message);
-    writeLine(stdout, usage());
+    writeLine(stderr, usage());
     return 1;
   }
 }
 
 async function analyzeCliProject(
-  parsed: CliArguments,
+  parsed: AnalysisCliArguments,
   projectRoot: string,
   stderr: Writer
 ) {
@@ -378,7 +388,7 @@ async function analyzeCliProject(
 
 async function handleCliResult(
   result: Awaited<ReturnType<typeof analyzeProject>> | null,
-  parsed: CliArguments,
+  parsed: AnalysisCliArguments,
   projectRoot: string,
   stdout: Writer,
   stderr: Writer,
@@ -388,7 +398,7 @@ async function handleCliResult(
     return 1;
   }
 
-  const elapsedSeconds = Math.max((performance.now() - startedAt) / 1000, Number.EPSILON);
+  const elapsedSeconds = (performance.now() - startedAt) / 1000;
   try {
     await writeCliReports(result, parsed, projectRoot, stdout, elapsedSeconds);
   } catch (error) {
@@ -401,7 +411,7 @@ async function handleCliResult(
 
 async function writeCliReports(
   result: Awaited<ReturnType<typeof analyzeProject>>,
-  parsed: CliArguments,
+  parsed: AnalysisCliArguments,
   projectRoot: string,
   stdout: Writer,
   elapsedSeconds: number
@@ -429,7 +439,7 @@ async function writeCliReports(
   }
 }
 
-async function validateCliReportPaths(parsed: CliArguments, projectRoot: string): Promise<void> {
+async function validateCliReportPaths(parsed: AnalysisCliArguments, projectRoot: string): Promise<void> {
   await validateReportPathTargets(projectRoot, [
     { label: "--output", path: parsed.output },
     { label: "--junit-report", path: parsed.junitReport }
@@ -438,8 +448,17 @@ async function validateCliReportPaths(parsed: CliArguments, projectRoot: string)
 
 async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {
   const absolutePath = path.resolve(projectRoot, reportPath);
+  assertInsideProjectRoot(path.resolve(projectRoot), absolutePath);
   await mkdir(path.dirname(absolutePath), { recursive: true });
   await writeFile(absolutePath, content);
+}
+
+function assertInsideProjectRoot(projectRoot: string, candidatePath: string): void {
+  const relativePath = path.relative(projectRoot, candidatePath);
+  if (relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))) {
+    return;
+  }
+  throw new Error("Report path must stay inside the project root");
 }
 
 function writeCliThresholdStatus(

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,30 +1,48 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 
 import { analyzeProject } from "./analyzeProject";
-import {
-  COGNITIVE_COMPLEXITY_THRESHOLD,
-  NO_ANALYZABLE_FUNCTIONS_MESSAGE,
-  NO_FILES_MESSAGE
-} from "./constants";
-import { formatReport } from "./report";
+import { COGNITIVE_COMPLEXITY_THRESHOLD, validateThreshold } from "./constants";
+import { formatAnalysisReport } from "./report";
+import { validateReportPathTargets } from "./reportPaths";
 import { writeLine } from "./utils";
-import type { CliArguments, Writer } from "./types";
+import type { CliArguments, ReportFormat, Writer } from "./types";
+
+const REPORT_FORMATS = ["toon", "json", "text", "junit", "none"] as const;
+const REPORT_FORMAT_LIST = REPORT_FORMATS.join(", ");
+const REPORT_FORMAT_ERROR = `--format requires one of: ${REPORT_FORMAT_LIST}`;
 
 const HELP_TEXT = `cognitive-typescript
 
 Usage:
   cognitive-typescript [--help]
-  cognitive-typescript [--changed]
-  cognitive-typescript <path ...>
+  cognitive-typescript [--changed] [--format <format>] [--agent] [--failures-only[=true|false]] [--omit-redundancy[=true|false]] [--output <path>] [--junit-report <path>] [--threshold <integer>]
+  cognitive-typescript [--format <format>] [--agent] [--failures-only[=true|false]] [--omit-redundancy[=true|false]] [--output <path>] [--junit-report <path>] [--threshold <integer>] <path ...>
 
 Options:
   --help                     Print usage to stdout
   --changed                  Analyze changed TypeScript files under src/
+  --format <format>          Emit ${REPORT_FORMAT_LIST} (default: toon)
+  --agent                    Default primary output to --format toon --failures-only --omit-redundancy
+  --failures-only[=true|false]
+                             Emit failed functions only in the primary report
+  --omit-redundancy[=true|false]
+                             Omit redundant per-method status in the primary report
+  --output <path>            Write the primary report to a file instead of stdout
+  --junit-report <path>      Also write a full JUnit XML report for CI test-report UIs
+  --threshold <integer>      Override the Cognitive Complexity threshold (default: 15)
 
 Behavior:
   (no args)                  Analyze all TypeScript files under any nested src/ tree
   <file ...>                 Analyze explicit TypeScript files
   <directory ...>            Analyze TypeScript files under each directory's nested src/ tree
+
+Exit codes:
+  0                          Analysis completed and threshold respected
+  1                          Parse or configuration error
+  2                          Cognitive Complexity threshold exceeded
+  3                          Unexpected internal error
 `;
 
 export function usage(): string {
@@ -32,15 +50,268 @@ export function usage(): string {
 }
 
 export function parseCliArguments(args: string[]): CliArguments {
-  if (args.length === 0) {
-    return { mode: "all", fileArgs: [] };
+  const state = createParseState();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith("--")) {
+      state.fileArgs.push(arg);
+      continue;
+    }
+    index = consumeOption(state, args, index);
   }
 
-  const state = createCliParseState();
-  for (const arg of args) {
-    applyCliArgument(state, arg);
-  }
   return finalizeCliArguments(state);
+}
+
+interface ParseState {
+  help: boolean;
+  changed: boolean;
+  format: ReportFormat;
+  threshold: number;
+  agent: boolean;
+  failuresOnly: boolean;
+  omitRedundancy: boolean;
+  output?: string;
+  junitReport?: string;
+  helpSeen: boolean;
+  changedSeen: boolean;
+  formatSeen: boolean;
+  thresholdSeen: boolean;
+  agentSeen: boolean;
+  failuresOnlySeen: boolean;
+  omitRedundancySeen: boolean;
+  outputSeen: boolean;
+  junitReportSeen: boolean;
+  fileArgs: string[];
+}
+
+type OptionHandler = (state: ParseState, args: string[], index: number, value: string | undefined) => number;
+type BooleanOptionHandler = (state: ParseState, value: string | undefined) => void;
+
+const OPTION_HANDLERS: Record<string, OptionHandler> = {
+  "--help": (state, _args, index) => {
+    ensureOptionIsUnique(state.helpSeen, "--help");
+    state.help = true;
+    state.helpSeen = true;
+    return index;
+  },
+  "--changed": (state, _args, index) => {
+    ensureOptionIsUnique(state.changedSeen, "--changed");
+    state.changed = true;
+    state.changedSeen = true;
+    return index;
+  },
+  "--agent": (state, _args, index) => {
+    ensureOptionIsUnique(state.agentSeen, "--agent");
+    state.agent = true;
+    state.agentSeen = true;
+    return index;
+  },
+  "--format": (state, args, index, value) => {
+    ensureOptionIsUnique(state.formatSeen, "--format");
+    state.format = parseReportFormat(optionValue(args, index, value, "--format", "one of: toon, json, text, junit, none"));
+    state.formatSeen = true;
+    return value === undefined ? index + 1 : index;
+  },
+  "--threshold": (state, args, index, value) => {
+    ensureOptionIsUnique(state.thresholdSeen, "--threshold");
+    state.threshold = parseThreshold(optionValue(args, index, value, "--threshold", "a positive integer"));
+    state.thresholdSeen = true;
+    return value === undefined ? index + 1 : index;
+  },
+  "--output": (state, args, index, value) => {
+    ensureOptionIsUnique(state.outputSeen, "--output");
+    state.output = parsePathOption(optionValue(args, index, value, "--output", "a path"), "--output");
+    state.outputSeen = true;
+    return value === undefined ? index + 1 : index;
+  },
+  "--junit-report": (state, args, index, value) => {
+    ensureOptionIsUnique(state.junitReportSeen, "--junit-report");
+    state.junitReport = parsePathOption(optionValue(args, index, value, "--junit-report", "a path"), "--junit-report");
+    state.junitReportSeen = true;
+    return value === undefined ? index + 1 : index;
+  }
+};
+
+const BOOLEAN_OPTION_HANDLERS: Record<string, BooleanOptionHandler> = {
+  "--failures-only": parseFailuresOnly,
+  "--omit-redundancy": parseOmitRedundancy
+};
+
+function createParseState(): ParseState {
+  return {
+    help: false,
+    changed: false,
+    format: "toon",
+    threshold: COGNITIVE_COMPLEXITY_THRESHOLD,
+    agent: false,
+    failuresOnly: false,
+    omitRedundancy: false,
+    output: undefined,
+    junitReport: undefined,
+    helpSeen: false,
+    changedSeen: false,
+    formatSeen: false,
+    thresholdSeen: false,
+    agentSeen: false,
+    failuresOnlySeen: false,
+    omitRedundancySeen: false,
+    outputSeen: false,
+    junitReportSeen: false,
+    fileArgs: []
+  };
+}
+
+function consumeOption(state: ParseState, args: string[], index: number): number {
+  const [option, value] = splitAssignedOption(args[index]);
+  const booleanHandler = BOOLEAN_OPTION_HANDLERS[option];
+  if (booleanHandler) {
+    booleanHandler(state, value);
+    return index;
+  }
+
+  const handler = OPTION_HANDLERS[option];
+  if (!handler) {
+    throw new Error(`Unknown option: ${args[index]}`);
+  }
+  return handler(state, args, index, value);
+}
+
+function ensureOptionIsUnique(seen: boolean, option: string): void {
+  if (seen) {
+    throw new Error(`${option} can only be provided once`);
+  }
+}
+
+function finalizeCliArguments(state: ParseState): CliArguments {
+  applyAgentDefaults(state);
+  validateCliState(state);
+
+  return {
+    mode: cliMode(state),
+    fileArgs: state.help ? [] : state.fileArgs,
+    format: state.format,
+    threshold: state.threshold,
+    agent: state.agent,
+    failuresOnly: state.failuresOnly,
+    omitRedundancy: state.omitRedundancy,
+    ...optionalPath("output", state.output),
+    ...optionalPath("junitReport", state.junitReport)
+  };
+}
+
+function applyAgentDefaults(state: ParseState): void {
+  if (!state.agent) {
+    return;
+  }
+  state.format = state.formatSeen ? state.format : "toon";
+  state.failuresOnly = state.failuresOnlySeen ? state.failuresOnly : true;
+  state.omitRedundancy = state.omitRedundancySeen ? state.omitRedundancy : true;
+}
+
+function validateCliState(state: ParseState): void {
+  if (state.help) {
+    return;
+  }
+  if (state.changed && state.fileArgs.length > 0) {
+    throw new Error("--changed cannot be combined with file arguments");
+  }
+}
+
+function cliMode(state: ParseState): CliArguments["mode"] {
+  if (state.help) {
+    return "help";
+  }
+  if (state.changed) {
+    return "changed";
+  }
+  return state.fileArgs.length > 0 ? "explicit" : "all";
+}
+
+function optionalPath<K extends "output" | "junitReport">(key: K, value: string | undefined): Pick<CliArguments, K> | {} {
+  return value === undefined ? {} : { [key]: value } as Pick<CliArguments, K>;
+}
+
+function parseReportFormat(value: string | undefined): ReportFormat {
+  if (value && isReportFormat(value)) {
+    return value;
+  }
+  throw new Error(REPORT_FORMAT_ERROR);
+}
+
+function isReportFormat(value: string): value is ReportFormat {
+  return (REPORT_FORMATS as readonly string[]).includes(value);
+}
+
+function parseThreshold(value: string): number {
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    throw new Error("--threshold requires a positive integer");
+  }
+  try {
+    return validateThreshold(Number(value));
+  } catch {
+    throw new Error("--threshold requires a positive integer");
+  }
+}
+
+function splitAssignedOption(arg: string): [string, string | undefined] {
+  const equalsIndex = arg.indexOf("=");
+  if (equalsIndex < 0) {
+    return [arg, undefined];
+  }
+  return [arg.slice(0, equalsIndex), arg.slice(equalsIndex + 1)];
+}
+
+function parseFailuresOnly(state: ParseState, value: string | undefined): void {
+  ensureOptionIsUnique(state.failuresOnlySeen, "--failures-only");
+  state.failuresOnly = parseBooleanOption(value, "--failures-only");
+  state.failuresOnlySeen = true;
+}
+
+function parseOmitRedundancy(state: ParseState, value: string | undefined): void {
+  ensureOptionIsUnique(state.omitRedundancySeen, "--omit-redundancy");
+  state.omitRedundancy = parseBooleanOption(value, "--omit-redundancy");
+  state.omitRedundancySeen = true;
+}
+
+function parseBooleanOption(value: string | undefined, option: string): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  throw new Error(`${option} requires true or false when a value is provided`);
+}
+
+function optionValue(
+  args: string[],
+  index: number,
+  inlineValue: string | undefined,
+  option: string,
+  valueDescription: string
+): string {
+  if (inlineValue !== undefined) {
+    if (inlineValue === "") {
+      throw new Error(`${option} requires ${valueDescription}`);
+    }
+    return inlineValue;
+  }
+  if (index + 1 >= args.length) {
+    throw new Error(`${option} requires ${valueDescription}`);
+  }
+  return args[index + 1];
+}
+
+function parsePathOption(value: string, option: string): string {
+  if (value.trim() === "") {
+    throw new Error(`${option} requires a path`);
+  }
+  return value;
 }
 
 export async function runCli(
@@ -54,14 +325,26 @@ export async function runCli(
     return parsed;
   }
   if (parsed.mode === "help") {
-    return writeHelp(stdout);
+    writeLine(stdout, usage());
+    return 0;
   }
 
-  const result = await analyzeCliProject(parsed, projectRoot, stderr);
-  if (!result) {
+  try {
+    await validateCliReportPaths(parsed, projectRoot);
+  } catch (error) {
+    writeLine(stderr, (error as Error).message);
     return 1;
   }
-  return handleCliResult(result, stdout, stderr);
+
+  const startedAt = performance.now();
+  return handleCliResult(
+    await analyzeCliProject(parsed, projectRoot, stderr),
+    parsed,
+    projectRoot,
+    stdout,
+    stderr,
+    startedAt
+  );
 }
 
 function parseCliInputs(args: string[], stdout: Writer, stderr: Writer): CliArguments | number {
@@ -83,7 +366,9 @@ async function analyzeCliProject(
     return await analyzeProject({
       projectRoot: path.resolve(projectRoot),
       explicitPaths: parsed.mode === "explicit" ? parsed.fileArgs : [],
-      changedOnly: parsed.mode === "changed"
+      changedOnly: parsed.mode === "changed",
+      threshold: parsed.threshold,
+      stderr
     });
   } catch (error) {
     writeLine(stderr, (error as Error).message);
@@ -91,98 +376,82 @@ async function analyzeCliProject(
   }
 }
 
-function writeHelp(stdout: Writer): number {
-  writeLine(stdout, usage());
-  return 0;
+async function handleCliResult(
+  result: Awaited<ReturnType<typeof analyzeProject>> | null,
+  parsed: CliArguments,
+  projectRoot: string,
+  stdout: Writer,
+  stderr: Writer,
+  startedAt: number
+): Promise<number> {
+  if (!result) {
+    return 1;
+  }
+
+  const elapsedSeconds = Math.max((performance.now() - startedAt) / 1000, Number.EPSILON);
+  try {
+    await writeCliReports(result, parsed, projectRoot, stdout, elapsedSeconds);
+  } catch (error) {
+    writeLine(stderr, (error as Error).message);
+    return 1;
+  }
+
+  return writeCliThresholdStatus(result, stderr);
 }
 
-function handleCliResult(
+async function writeCliReports(
   result: Awaited<ReturnType<typeof analyzeProject>>,
+  parsed: CliArguments,
+  projectRoot: string,
   stdout: Writer,
+  elapsedSeconds: number
+): Promise<void> {
+  const primaryReport = formatAnalysisReport(result.metrics, {
+    format: parsed.format,
+    agent: parsed.agent,
+    threshold: result.threshold,
+    failuresOnly: parsed.failuresOnly,
+    omitRedundancy: parsed.omitRedundancy,
+    elapsedSeconds
+  });
+  if (parsed.output) {
+    await writeReportFile(projectRoot, parsed.output, primaryReport);
+  } else if (primaryReport.length > 0) {
+    stdout.write(primaryReport);
+  }
+
+  if (parsed.junitReport) {
+    await writeReportFile(projectRoot, parsed.junitReport, formatAnalysisReport(result.metrics, {
+      format: "junit",
+      threshold: result.threshold,
+      elapsedSeconds
+    }));
+  }
+}
+
+async function validateCliReportPaths(parsed: CliArguments, projectRoot: string): Promise<void> {
+  await validateReportPathTargets(projectRoot, [
+    { label: "--output", path: parsed.output },
+    { label: "--junit-report", path: parsed.junitReport }
+  ]);
+}
+
+async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {
+  const absolutePath = path.resolve(projectRoot, reportPath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content);
+}
+
+function writeCliThresholdStatus(
+  result: Awaited<ReturnType<typeof analyzeProject>>,
   stderr: Writer
 ): number {
-  const earlyExit = resolveCliEarlyExit(result, stdout);
-  if (earlyExit !== null) {
-    return earlyExit;
-  }
-  writeLine(stdout, formatReport(result.metrics));
-  return writeThresholdStatus(result, stderr);
-}
-
-function resolveCliEarlyExit(result: Awaited<ReturnType<typeof analyzeProject>>, stdout: Writer): number | null {
-  if (result.selectedFiles.length === 0) {
-    writeLine(stdout, NO_FILES_MESSAGE);
-    return 0;
-  }
-  if (result.metrics.length === 0) {
-    writeLine(stdout, NO_ANALYZABLE_FUNCTIONS_MESSAGE);
-    return 0;
-  }
-  return null;
-}
-
-function writeThresholdStatus(result: Awaited<ReturnType<typeof analyzeProject>>, stderr: Writer): number {
   if (!result.thresholdExceeded) {
     return 0;
   }
   writeLine(
     stderr,
-    `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${COGNITIVE_COMPLEXITY_THRESHOLD}`
+    `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${result.threshold}`
   );
   return 2;
-}
-
-interface CliParseState {
-  help: boolean;
-  changed: boolean;
-  fileArgs: string[];
-}
-
-function createCliParseState(): CliParseState {
-  return {
-    help: false,
-    changed: false,
-    fileArgs: []
-  };
-}
-
-function applyCliArgument(state: CliParseState, arg: string): void {
-  if (!arg.startsWith("--")) {
-    state.fileArgs.push(arg);
-    return;
-  }
-  applyCliOption(state, arg);
-}
-
-function applyCliOption(state: CliParseState, arg: string): void {
-  switch (arg) {
-    case "--help":
-      state.help = true;
-      return;
-    case "--changed":
-      state.changed = true;
-      return;
-    default:
-      throw new Error(`Unknown option: ${arg}`);
-  }
-}
-
-function finalizeCliArguments(state: CliParseState): CliArguments {
-  if (state.help) {
-    return { mode: "help", fileArgs: [] };
-  }
-  if (state.changed && state.fileArgs.length > 0) {
-    throw new Error("--changed cannot be combined with file arguments");
-  }
-  return {
-    mode: resolveCliMode(state),
-    fileArgs: state.fileArgs
-  };
-}
-
-function resolveCliMode(state: CliParseState): CliArguments["mode"] {
-  if (state.changed) {
-    return "changed";
-  }
-  return state.fileArgs.length > 0 ? "explicit" : "all";
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,6 +2,13 @@ export const COGNITIVE_COMPLEXITY_THRESHOLD = 15;
 export const NO_FILES_MESSAGE = "No TypeScript files to analyze.";
 export const NO_ANALYZABLE_FUNCTIONS_MESSAGE = "No function-like bodies to analyze.";
 
+export function validateThreshold(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error("Threshold must be a positive integer");
+  }
+  return value;
+}
+
 export const IGNORED_DIRECTORIES = new Set([
   ".git",
   "coverage",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,9 +19,10 @@ export {
 } from "./constants";
 export type {
   AnalysisResult,
+  AnalysisCliArguments,
   AnalyzeProjectOptions,
   CliArguments,
-  MethodReportStatus,
+  HelpCliArguments,
   MethodDescriptor,
   MethodMetrics,
   ReportFormat,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,16 @@ export { analyzeProject } from "./analyzeProject";
 export { runCli, parseCliArguments, usage } from "./cli";
 export { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots, isAnalyzableFile } from "./fileSelection";
 export { parseFileMethods } from "./parser";
-export { formatReport, sortMetrics } from "./report";
+export {
+  buildAgentAnalysisReport,
+  buildAnalysisReport,
+  formatAnalysisReport,
+  formatJunitReport,
+  formatReport,
+  formatTextReport,
+  formatToonReport,
+  sortMetrics
+} from "./report";
 export {
   COGNITIVE_COMPLEXITY_THRESHOLD,
   NO_FILES_MESSAGE,
@@ -12,7 +21,17 @@ export type {
   AnalysisResult,
   AnalyzeProjectOptions,
   CliArguments,
+  MethodReportStatus,
   MethodDescriptor,
   MethodMetrics,
+  ReportFormat,
+  ReportStatus,
   Writer
 } from "./types";
+export type {
+  AnalysisReport,
+  CompactAnalysisReport,
+  CompactMethodReportEntry,
+  FormatAnalysisReportOptions,
+  MethodReportEntry
+} from "./report";

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -99,17 +99,37 @@ export function buildAgentAnalysisReport(
 }
 
 export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAnalysisReportOptions): string {
-  const validatedThreshold = validateThreshold(options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD);
-  if (options.format === "none") {
+  const prepared = prepareFormatRequest(options);
+  if (prepared.format === "none") {
     return "";
   }
 
+  const report = buildAnalysisReport(metrics, prepared.threshold, prepared.failuresOnly);
+  const primaryReport = prepared.omitMethodStatus ? omitMethodStatuses(report) : report;
+  return REPORT_FORMATTERS[prepared.format](primaryReport, prepared.omitRedundancy, prepared.elapsedSeconds);
+}
+
+interface PreparedFormatRequest {
+  elapsedSeconds: number;
+  failuresOnly: boolean;
+  format: ReportFormat;
+  omitMethodStatus: boolean;
+  omitRedundancy: boolean;
+  threshold: number;
+}
+
+function prepareFormatRequest(options: FormatAnalysisReportOptions): PreparedFormatRequest {
+  const format = options.format;
   const agent = options.agent ?? false;
-  const failuresOnly = options.failuresOnly ?? agent;
   const omitRedundancy = options.omitRedundancy ?? agent;
-  const report = buildAnalysisReport(metrics, validatedThreshold, failuresOnly);
-  const primaryReport = omitRedundancy && options.format !== "junit" ? omitMethodStatuses(report) : report;
-  return REPORT_FORMATTERS[options.format](primaryReport, omitRedundancy, options.elapsedSeconds ?? 0);
+  return {
+    format,
+    threshold: validateThreshold(options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD),
+    failuresOnly: options.failuresOnly ?? agent,
+    omitRedundancy,
+    omitMethodStatus: omitRedundancy && format !== "junit",
+    elapsedSeconds: options.elapsedSeconds ?? 0
+  };
 }
 
 export function formatReport(metrics: MethodMetrics[]): string {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -1,34 +1,345 @@
-import type { MethodMetrics } from "./types";
+import { XMLBuilder } from "fast-xml-parser";
 
-const HEADERS = ["Function", "Cognitive Complexity", "Location"];
+import { COGNITIVE_COMPLEXITY_THRESHOLD, validateThreshold } from "./constants";
+import type {
+  MethodMetrics,
+  MethodReportStatus,
+  ReportFormat,
+  ReportStatus
+} from "./types";
+
+const METHOD_COLUMNS = ["status", "cc", "method", "src", "lineStart", "lineEnd"] as const;
+const COMPACT_METHOD_COLUMNS = ["cc", "method", "src", "lineStart", "lineEnd"] as const;
+const RIGHT_ALIGNED_TEXT_COLUMNS = new Set<MethodColumn>(["cc", "lineStart", "lineEnd"]);
+
+export interface MethodReportEntry {
+  status: MethodReportStatus;
+  cc: number;
+  method: string;
+  src: string;
+  lineStart: number;
+  lineEnd: number;
+}
+
+export type CompactMethodReportEntry = Omit<MethodReportEntry, "status">;
+
+export interface AnalysisReport {
+  status: ReportStatus;
+  threshold: number;
+  methods: MethodReportEntry[];
+}
+
+export interface CompactAnalysisReport {
+  status: ReportStatus;
+  threshold: number;
+  methods: CompactMethodReportEntry[];
+}
+
+export interface FormatAnalysisReportOptions {
+  format: ReportFormat;
+  agent?: boolean;
+  threshold?: number;
+  failuresOnly?: boolean;
+  omitRedundancy?: boolean;
+  elapsedSeconds?: number;
+}
+
+type SerializableReport = AnalysisReport | CompactAnalysisReport;
+type ReportValue = string | number;
+type ReportFormatter = (report: SerializableReport, omitMethodStatus: boolean, elapsedSeconds: number) => string;
+type MethodColumn = typeof METHOD_COLUMNS[number];
+type CompactMethodColumn = typeof COMPACT_METHOD_COLUMNS[number];
+type XmlNode = Record<string, unknown>;
+
+const REPORT_FORMATTERS: Record<ReportFormat, ReportFormatter> = {
+  toon: formatToonReport,
+  json: (report) => `${JSON.stringify(report, null, 2)}\n`,
+  text: formatTextReport,
+  junit: (report, omitMethodStatus, elapsedSeconds) =>
+    formatJunitReport(report as AnalysisReport, omitMethodStatus, elapsedSeconds),
+  none: () => ""
+};
 
 export function sortMetrics(metrics: MethodMetrics[]): MethodMetrics[] {
   return [...metrics].sort((left, right) => {
     if (left.cognitiveComplexity !== right.cognitiveComplexity) {
       return right.cognitiveComplexity - left.cognitiveComplexity;
     }
-    if (left.relativePath !== right.relativePath) {
-      return left.relativePath.localeCompare(right.relativePath);
+    const sourceComparison = compareStable(left.relativePath, right.relativePath);
+    if (sourceComparison !== 0) {
+      return sourceComparison;
+    }
+    const methodComparison = compareStable(left.displayName, right.displayName);
+    if (methodComparison !== 0) {
+      return methodComparison;
     }
     return left.startLine - right.startLine;
   });
 }
 
-export function formatReport(metrics: MethodMetrics[]): string {
-  const rows = sortMetrics(metrics).map((metric) => [
-    metric.displayName,
-    String(metric.cognitiveComplexity),
-    metric.location
-  ]);
-
-  const widths = HEADERS.map((header, index) => {
-    const rowWidth = rows.reduce((max, row) => Math.max(max, row[index].length), header.length);
-    return rowWidth;
-  });
-
-  const headerLine = HEADERS.map((header, index) => header.padEnd(widths[index])).join("  ");
-  const separator = widths.map((width) => "-".repeat(width)).join("  ");
-  const body = rows.map((row) => row.map((value, index) => value.padEnd(widths[index])).join("  "));
-  return [headerLine, separator, ...body].join("\n");
+export function buildAnalysisReport(
+  metrics: MethodMetrics[],
+  threshold = COGNITIVE_COMPLEXITY_THRESHOLD,
+  failuresOnly = false
+): AnalysisReport {
+  threshold = validateThreshold(threshold);
+  const allMethods = sortMetrics(metrics).map((metric) => toMethodReportEntry(metric, threshold));
+  return {
+    status: allMethods.some((method) => method.status === "failed") ? "failed" : "passed",
+    threshold,
+    methods: failuresOnly ? allMethods.filter((method) => method.status === "failed") : allMethods
+  };
 }
 
+export function buildAgentAnalysisReport(
+  metrics: MethodMetrics[],
+  threshold = COGNITIVE_COMPLEXITY_THRESHOLD
+): CompactAnalysisReport {
+  const report = buildAnalysisReport(metrics, threshold, true);
+  return omitMethodStatuses(report);
+}
+
+export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAnalysisReportOptions): string {
+  const threshold = options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD;
+  validateThreshold(threshold);
+  if (options.format === "none") {
+    return "";
+  }
+
+  const agent = options.agent ?? false;
+  const failuresOnly = options.failuresOnly ?? agent;
+  const omitRedundancy = options.omitRedundancy ?? agent;
+  const report = buildAnalysisReport(metrics, threshold, failuresOnly);
+  const primaryReport = omitRedundancy && options.format !== "junit" ? omitMethodStatuses(report) : report;
+  return REPORT_FORMATTERS[options.format](primaryReport, omitRedundancy, options.elapsedSeconds ?? 0);
+}
+
+export function formatReport(metrics: MethodMetrics[]): string {
+  return formatTextReport(buildAnalysisReport(metrics), false);
+}
+
+export function formatToonReport(report: SerializableReport, omitMethodStatus = false): string {
+  const toonReport = omitMethodStatus && reportHasMethodStatus(report)
+    ? omitMethodStatuses(report)
+    : report;
+  return encodeToonReport(toonReport);
+}
+
+export function formatTextReport(report: SerializableReport, omitMethodStatus = false): string {
+  const summary = [`status: ${report.status}`, `threshold: ${report.threshold}`];
+  if (report.methods.length === 0) {
+    return `${summary.join("\n")}\nmethods[0]:\n`;
+  }
+
+  const includeStatus = !omitMethodStatus && reportHasMethodStatus(report);
+  const columns = includeStatus ? METHOD_COLUMNS : COMPACT_METHOD_COLUMNS;
+  const rows = includeStatus
+    ? report.methods.map((method) => METHOD_COLUMNS.map((column) => formatTextValue(method[column])))
+    : (report as CompactAnalysisReport).methods.map((method) =>
+      COMPACT_METHOD_COLUMNS.map((column) => formatTextValue(method[column]))
+    );
+  const widths = columns.map((column, index) =>
+    rows.reduce((max, row) => Math.max(max, row[index].length), column.length)
+  );
+  const headerLine = formatTextRow([...columns], widths, columns);
+  const separator = formatTextSeparator(widths);
+  const body = rows.map((row) => formatTextRow(row, widths, columns));
+
+  return [...summary, "", headerLine, separator, ...body].join("\n") + "\n";
+}
+
+export function formatJunitReport(
+  report: AnalysisReport,
+  omitRedundancy = false,
+  elapsedSeconds = 0
+): string {
+  return `${formatXmlDeclaration()}\n${createXmlBuilder().build(toJunitXml(report, omitRedundancy, elapsedSeconds)).trimEnd()}\n`;
+}
+
+function toMethodReportEntry(metric: MethodMetrics, threshold: number): MethodReportEntry {
+  return {
+    status: metric.cognitiveComplexity > threshold ? "failed" : "passed",
+    cc: metric.cognitiveComplexity,
+    method: metric.displayName,
+    src: metric.relativePath,
+    lineStart: metric.startLine,
+    lineEnd: metric.endLine
+  };
+}
+
+function reportHasMethodStatus(report: SerializableReport): report is AnalysisReport {
+  return report.methods.length > 0 && report.methods.every((method) => "status" in method);
+}
+
+function omitMethodStatuses(report: AnalysisReport): CompactAnalysisReport {
+  return {
+    status: report.status,
+    threshold: report.threshold,
+    methods: report.methods.map(({ status: _status, ...method }) => method)
+  };
+}
+
+function compareStable(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+function formatTextValue(value: ReportValue): string {
+  return String(value);
+}
+
+function formatTextRow(
+  values: string[],
+  widths: number[],
+  columns: readonly (MethodColumn | CompactMethodColumn)[] = METHOD_COLUMNS
+): string {
+  return `| ${values.map((value, index) => formatTextCell(value, widths[index], columns[index])).join(" | ")} |`;
+}
+
+function formatTextCell(value: string, width: number, column: MethodColumn | CompactMethodColumn): string {
+  return RIGHT_ALIGNED_TEXT_COLUMNS.has(column as MethodColumn) ? value.padStart(width) : value.padEnd(width);
+}
+
+function formatTextSeparator(widths: number[]): string {
+  return `| ${widths.map((width) => "-".repeat(width)).join(" | ")} |`;
+}
+
+function encodeToonReport(report: SerializableReport): string {
+  const columns = reportHasMethodStatus(report) ? METHOD_COLUMNS : COMPACT_METHOD_COLUMNS;
+  const rows = report.methods.map((method) =>
+    columns.map((column) => toonValue((method as Record<string, ReportValue>)[column])).join(",")
+  );
+  return [
+    `status: ${report.status}`,
+    `threshold: ${report.threshold}`,
+    `methods[${report.methods.length}]${report.methods.length === 0 ? "" : `{${columns.join(",")}}`}:`,
+    ...rows.map((row) => `  ${row}`)
+  ].join("\n") + "\n";
+}
+
+function toonValue(value: ReportValue): string {
+  const text = String(value);
+  return /[",\n]/.test(text) ? JSON.stringify(text) : text;
+}
+
+function methodProperties(entry: MethodReportEntry, omitRedundancy: boolean): Array<[string, string]> {
+  const properties: Array<[string, string]> = [
+    ["cc", String(entry.cc)],
+    ["method", entry.method],
+    ["src", entry.src],
+    ["lineStart", String(entry.lineStart)],
+    ["lineEnd", String(entry.lineEnd)]
+  ];
+  return omitRedundancy ? properties : [["status", entry.status], ...properties];
+}
+
+function formatXmlDeclaration(): string {
+  return '<?xml version="1.0" encoding="UTF-8"?>';
+}
+
+function createXmlBuilder(): XMLBuilder {
+  return new XMLBuilder({
+    attributeNamePrefix: "@_",
+    format: true,
+    ignoreAttributes: false,
+    suppressEmptyNode: true
+  });
+}
+
+function toJunitXml(report: AnalysisReport, omitRedundancy: boolean, elapsedSeconds: number): XmlNode {
+  const failures = report.methods.filter((method) => method.status === "failed").length;
+  const time = formatTime(elapsedSeconds);
+  const testcaseTime = formatTime(report.methods.length === 0 ? 0 : elapsedSeconds / report.methods.length);
+  const testsuite: XmlNode = {
+    "@_name": "cognitive-typescript",
+    "@_status": report.status,
+    "@_tests": report.methods.length,
+    "@_failures": failures,
+    "@_skipped": 0,
+    "@_errors": 0,
+    "@_time": time,
+    properties: {
+      property: [toXmlProperty("threshold", String(report.threshold))]
+    }
+  };
+
+  if (report.methods.length > 0) {
+    testsuite.testcase = report.methods.map((method) =>
+      toJunitTestcaseXml(method, report.threshold, omitRedundancy, testcaseTime)
+    );
+  }
+
+  return {
+    testsuites: {
+      "@_name": "cognitive-typescript",
+      "@_tests": report.methods.length,
+      "@_failures": failures,
+      "@_skipped": 0,
+      "@_errors": 0,
+      "@_time": time,
+      testsuite
+    }
+  };
+}
+
+function toJunitTestcaseXml(
+  entry: MethodReportEntry,
+  threshold: number,
+  omitRedundancy: boolean,
+  time: string
+): XmlNode {
+  return {
+    "@_classname": entry.src,
+    "@_name": junitTestcaseName(entry),
+    "@_file": entry.src,
+    "@_time": time,
+    "@_line": entry.lineStart,
+    properties: {
+      property: methodProperties(entry, omitRedundancy).map(([name, value]) => toXmlProperty(name, value))
+    },
+    ...junitStatusXml(entry, threshold)
+  };
+}
+
+function junitTestcaseName(entry: MethodReportEntry): string {
+  return `${entry.method}:${entry.lineStart}`;
+}
+
+function toXmlProperty(name: string, value: string): XmlNode {
+  return {
+    "@_name": name,
+    "@_value": value
+  };
+}
+
+function junitStatusXml(entry: MethodReportEntry, threshold: number): XmlNode {
+  if (entry.status !== "failed") {
+    return {};
+  }
+  const message = `Cognitive Complexity threshold exceeded: ${entry.cc} > ${threshold}`;
+  return {
+    failure: {
+      "@_type": "cognitive-typescript.threshold",
+      "@_message": message,
+      "#text": junitDiagnosticText(entry, threshold)
+    }
+  };
+}
+
+function junitDiagnosticText(entry: MethodReportEntry, threshold: number): string {
+  return [
+    `Cognitive Complexity: ${entry.cc}`,
+    `Threshold: ${threshold}`,
+    `Source: ${entry.src}:${entry.lineStart}-${entry.lineEnd}`,
+    `Method: ${entry.method}`
+  ].join("\n");
+}
+
+function formatTime(elapsedSeconds: number): string {
+  return Math.max(0, elapsedSeconds).toFixed(6);
+}

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -3,7 +3,6 @@ import { XMLBuilder } from "fast-xml-parser";
 import { COGNITIVE_COMPLEXITY_THRESHOLD, validateThreshold } from "./constants";
 import type {
   MethodMetrics,
-  MethodReportStatus,
   ReportFormat,
   ReportStatus
 } from "./types";
@@ -13,7 +12,7 @@ const COMPACT_METHOD_COLUMNS = ["cc", "method", "src", "lineStart", "lineEnd"] a
 const RIGHT_ALIGNED_TEXT_COLUMNS = new Set<MethodColumn>(["cc", "lineStart", "lineEnd"]);
 
 export interface MethodReportEntry {
-  status: MethodReportStatus;
+  status: ReportStatus;
   cc: number;
   method: string;
   src: string;
@@ -80,14 +79,14 @@ export function sortMetrics(metrics: MethodMetrics[]): MethodMetrics[] {
 export function buildAnalysisReport(
   metrics: MethodMetrics[],
   threshold = COGNITIVE_COMPLEXITY_THRESHOLD,
-  failuresOnly = false
+  filterToFailures = false
 ): AnalysisReport {
-  threshold = validateThreshold(threshold);
-  const allMethods = sortMetrics(metrics).map((metric) => toMethodReportEntry(metric, threshold));
+  const validatedThreshold = validateThreshold(threshold);
+  const allMethods = sortMetrics(metrics).map((metric) => toMethodReportEntry(metric, validatedThreshold));
   return {
     status: allMethods.some((method) => method.status === "failed") ? "failed" : "passed",
-    threshold,
-    methods: failuresOnly ? allMethods.filter((method) => method.status === "failed") : allMethods
+    threshold: validatedThreshold,
+    methods: filterToFailures ? allMethods.filter((method) => method.status === "failed") : allMethods
   };
 }
 
@@ -100,8 +99,7 @@ export function buildAgentAnalysisReport(
 }
 
 export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAnalysisReportOptions): string {
-  const threshold = options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD;
-  validateThreshold(threshold);
+  const validatedThreshold = validateThreshold(options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD);
   if (options.format === "none") {
     return "";
   }
@@ -109,7 +107,7 @@ export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAn
   const agent = options.agent ?? false;
   const failuresOnly = options.failuresOnly ?? agent;
   const omitRedundancy = options.omitRedundancy ?? agent;
-  const report = buildAnalysisReport(metrics, threshold, failuresOnly);
+  const report = buildAnalysisReport(metrics, validatedThreshold, failuresOnly);
   const primaryReport = omitRedundancy && options.format !== "junit" ? omitMethodStatuses(report) : report;
   return REPORT_FORMATTERS[options.format](primaryReport, omitRedundancy, options.elapsedSeconds ?? 0);
 }
@@ -168,7 +166,7 @@ function toMethodReportEntry(metric: MethodMetrics, threshold: number): MethodRe
 }
 
 function reportHasMethodStatus(report: SerializableReport): report is AnalysisReport {
-  return report.methods.length > 0 && report.methods.every((method) => "status" in method);
+  return report.methods.length === 0 || report.methods.every((method) => "status" in method);
 }
 
 function omitMethodStatuses(report: AnalysisReport): CompactAnalysisReport {
@@ -341,5 +339,8 @@ function junitDiagnosticText(entry: MethodReportEntry, threshold: number): strin
 }
 
 function formatTime(elapsedSeconds: number): string {
-  return Math.max(0, elapsedSeconds).toFixed(6);
+  if (elapsedSeconds <= 0) {
+    return "0.000000";
+  }
+  return Math.max(elapsedSeconds, 1e-6).toFixed(6);
 }

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 
 export interface ReportPathTarget {
@@ -159,33 +159,12 @@ function normalizeReportPathForCollision(filePath: string, caseInsensitiveFilesy
 }
 
 async function isCaseInsensitiveFilesystem(projectRoot: string): Promise<boolean> {
-  const probeDirectory = await createCaseProbeDirectory(projectRoot);
-  if (probeDirectory === undefined) {
-    return defaultCaseInsensitiveFilesystem();
-  }
-
-  try {
-    const probeFile = path.join(probeDirectory, "cognitive-typescript-case-probe");
-    await writeFile(probeFile, "");
-    await access(path.join(probeDirectory, "COGNITIVE-TYPESCRIPT-CASE-PROBE"));
-    return true;
-  } catch (error) {
-    return isMissingPathError(error) ? false : defaultCaseInsensitiveFilesystem();
-  } finally {
-    await rm(probeDirectory, { force: true, recursive: true });
-  }
+  void projectRoot;
+  return defaultCaseInsensitiveFilesystem();
 }
 
 function defaultCaseInsensitiveFilesystem(): boolean {
   return process.platform === "win32" || process.platform === "darwin";
-}
-
-async function createCaseProbeDirectory(projectRoot: string): Promise<string | undefined> {
-  try {
-    return await mkdtemp(path.join(projectRoot, ".cognitive-typescript-case-"));
-  } catch {
-    return undefined;
-  }
 }
 
 function isFilesystemRoot(filePath: string): boolean {

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -45,28 +45,16 @@ async function resolveReportPathTarget(
   filesystemCaseCache: FilesystemCaseCache
 ): Promise<ResolvedReportPathTarget> {
   const absolutePath = path.resolve(projectRoot, target.path);
-  if (isFilesystemRoot(absolutePath)) {
-    throw new Error(`${target.label} must target a report file, not a filesystem root`);
-  }
-  if (absolutePath === projectRoot) {
-    throw new Error(`${target.label} must target a report file, not the project root`);
-  }
+  assertReportTargetPath(projectRoot, absolutePath, target.label);
   assertInsideProjectRoot(projectRoot, absolutePath, target.label);
-
-  const stats = await statIfExists(absolutePath);
-  if (stats?.isDirectory()) {
-    throw new Error(`${target.label} must target a report file, not an existing directory`);
-  }
-
+  await assertTargetIsNotDirectory(absolutePath, target.label);
   const canonicalPath = await canonicalizeReportPath(absolutePath);
-  const canonicalRoot = await canonicalizeExistingParent(projectRoot);
-  if (!isInsidePath(canonicalRoot, canonicalPath)) {
-    throw new Error(`${target.label} must stay inside the project root`);
-  }
-
-  const caseInsensitiveFilesystem = shouldCheckCaseCollisions
-    ? await caseInsensitiveFilesystemForTarget(absolutePath, filesystemCaseCache)
-    : false;
+  await assertCanonicalPathInsideProjectRoot(projectRoot, canonicalPath, target.label);
+  const caseInsensitiveFilesystem = await collisionCaseSensitivity(
+    shouldCheckCaseCollisions,
+    absolutePath,
+    filesystemCaseCache
+  );
 
   return {
     label: target.label,
@@ -74,6 +62,44 @@ async function resolveReportPathTarget(
     absolutePath,
     collisionPath: normalizeReportPathForCollision(canonicalPath, caseInsensitiveFilesystem)
   };
+}
+
+function assertReportTargetPath(projectRoot: string, absolutePath: string, label: string): void {
+  if (isFilesystemRoot(absolutePath)) {
+    throw new Error(`${label} must target a report file, not a filesystem root`);
+  }
+  if (absolutePath === projectRoot) {
+    throw new Error(`${label} must target a report file, not the project root`);
+  }
+}
+
+async function assertTargetIsNotDirectory(absolutePath: string, label: string): Promise<void> {
+  const stats = await statIfExists(absolutePath);
+  if (stats?.isDirectory()) {
+    throw new Error(`${label} must target a report file, not an existing directory`);
+  }
+}
+
+async function assertCanonicalPathInsideProjectRoot(
+  projectRoot: string,
+  canonicalPath: string,
+  label: string
+): Promise<void> {
+  const canonicalRoot = await canonicalizeExistingParent(projectRoot);
+  if (!isInsidePath(canonicalRoot, canonicalPath)) {
+    throw new Error(`${label} must stay inside the project root`);
+  }
+}
+
+async function collisionCaseSensitivity(
+  shouldCheckCaseCollisions: boolean,
+  absolutePath: string,
+  filesystemCaseCache: FilesystemCaseCache
+): Promise<boolean> {
+  if (!shouldCheckCaseCollisions) {
+    return false;
+  }
+  return caseInsensitiveFilesystemForTarget(absolutePath, filesystemCaseCache);
 }
 
 async function caseInsensitiveFilesystemForTarget(
@@ -131,18 +157,45 @@ async function canonicalizeReportPath(filePath: string): Promise<string> {
 }
 
 async function canonicalizeExistingParent(directoryPath: string): Promise<string> {
+  const resolved = await resolveCanonicalParent(directoryPath);
+  return resolved.missingSegments.reduce(
+    (currentPath, segment) => path.join(currentPath, segment),
+    resolved.canonicalPath
+  );
+}
+
+interface CanonicalParentResolution {
+  canonicalPath: string;
+  missingSegments: string[];
+}
+
+async function resolveCanonicalParent(directoryPath: string): Promise<CanonicalParentResolution> {
   try {
-    return await realpath(directoryPath);
+    return {
+      canonicalPath: await realpath(directoryPath),
+      missingSegments: []
+    };
   } catch (error) {
     if (!isMissingPathError(error)) {
       throw error;
     }
-    const parent = path.dirname(directoryPath);
-    if (parent === directoryPath) {
-      return directoryPath;
-    }
-    return path.join(await canonicalizeExistingParent(parent), path.basename(directoryPath));
+    return resolveMissingCanonicalParent(directoryPath);
   }
+}
+
+async function resolveMissingCanonicalParent(directoryPath: string): Promise<CanonicalParentResolution> {
+  const parent = path.dirname(directoryPath);
+  if (parent === directoryPath) {
+    return {
+      canonicalPath: directoryPath,
+      missingSegments: []
+    };
+  }
+  const resolvedParent = await resolveCanonicalParent(parent);
+  return {
+    canonicalPath: resolvedParent.canonicalPath,
+    missingSegments: [...resolvedParent.missingSegments, path.basename(directoryPath)]
+  };
 }
 
 async function nearestExistingParent(directoryPath: string): Promise<string> {

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -51,9 +51,7 @@ async function resolveReportPathTarget(
   if (absolutePath === projectRoot) {
     throw new Error(`${target.label} must target a report file, not the project root`);
   }
-  if (!isInsidePath(projectRoot, absolutePath)) {
-    throw new Error(`${target.label} must stay inside the project root`);
-  }
+  assertInsideProjectRoot(projectRoot, absolutePath, target.label);
 
   const stats = await statIfExists(absolutePath);
   if (stats?.isDirectory()) {
@@ -87,9 +85,15 @@ async function caseInsensitiveFilesystemForTarget(
   if (cached !== undefined) {
     return cached;
   }
-  const caseInsensitiveFilesystem = await isCaseInsensitiveFilesystem(parent);
+  const caseInsensitiveFilesystem = defaultCaseInsensitiveFilesystem();
   filesystemCaseCache.set(parent, caseInsensitiveFilesystem);
   return caseInsensitiveFilesystem;
+}
+
+export function assertInsideProjectRoot(projectRoot: string, candidatePath: string, label: string): void {
+  if (!isInsidePath(projectRoot, candidatePath)) {
+    throw new Error(`${label} must stay inside the project root`);
+  }
 }
 
 async function statIfExists(filePath: string): Promise<Awaited<ReturnType<typeof stat>> | undefined> {
@@ -156,11 +160,6 @@ async function nearestExistingParent(directoryPath: string): Promise<string> {
 function normalizeReportPathForCollision(filePath: string, caseInsensitiveFilesystem: boolean): string {
   const normalized = path.normalize(filePath);
   return caseInsensitiveFilesystem ? normalized.toLowerCase() : normalized;
-}
-
-async function isCaseInsensitiveFilesystem(projectRoot: string): Promise<boolean> {
-  void projectRoot;
-  return defaultCaseInsensitiveFilesystem();
 }
 
 function defaultCaseInsensitiveFilesystem(): boolean {

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -13,8 +13,6 @@ interface ResolvedReportPathTarget {
   collisionPath: string;
 }
 
-type FilesystemCaseCache = Map<string, boolean>;
-
 export async function validateReportPathTargets(
   projectRoot: string,
   targets: ReportPathTarget[]
@@ -24,10 +22,9 @@ export async function validateReportPathTargets(
     target.path !== undefined
   ));
   const shouldCheckCaseCollisions = reportTargets.length > 1;
-  const filesystemCaseCache: FilesystemCaseCache = new Map();
   const resolvedTargets = await Promise.all(
     reportTargets.map((target) => (
-      resolveReportPathTarget(root, target, shouldCheckCaseCollisions, filesystemCaseCache)
+      resolveReportPathTarget(root, target, shouldCheckCaseCollisions)
     ))
   );
 
@@ -41,8 +38,7 @@ export async function validateReportPathTargets(
 async function resolveReportPathTarget(
   projectRoot: string,
   target: { label: string; path: string },
-  shouldCheckCaseCollisions: boolean,
-  filesystemCaseCache: FilesystemCaseCache
+  shouldCheckCaseCollisions: boolean
 ): Promise<ResolvedReportPathTarget> {
   const absolutePath = path.resolve(projectRoot, target.path);
   assertReportTargetPath(projectRoot, absolutePath, target.label);
@@ -50,11 +46,7 @@ async function resolveReportPathTarget(
   await assertTargetIsNotDirectory(absolutePath, target.label);
   const canonicalPath = await canonicalizeReportPath(absolutePath);
   await assertCanonicalPathInsideProjectRoot(projectRoot, canonicalPath, target.label);
-  const caseInsensitiveFilesystem = await collisionCaseSensitivity(
-    shouldCheckCaseCollisions,
-    absolutePath,
-    filesystemCaseCache
-  );
+  const caseInsensitiveFilesystem = collisionCaseSensitivity(shouldCheckCaseCollisions);
 
   return {
     label: target.label,
@@ -91,29 +83,11 @@ async function assertCanonicalPathInsideProjectRoot(
   }
 }
 
-async function collisionCaseSensitivity(
-  shouldCheckCaseCollisions: boolean,
-  absolutePath: string,
-  filesystemCaseCache: FilesystemCaseCache
-): Promise<boolean> {
+function collisionCaseSensitivity(shouldCheckCaseCollisions: boolean): boolean {
   if (!shouldCheckCaseCollisions) {
     return false;
   }
-  return caseInsensitiveFilesystemForTarget(absolutePath, filesystemCaseCache);
-}
-
-async function caseInsensitiveFilesystemForTarget(
-  absolutePath: string,
-  filesystemCaseCache: FilesystemCaseCache
-): Promise<boolean> {
-  const parent = await nearestExistingParent(path.dirname(absolutePath));
-  const cached = filesystemCaseCache.get(parent);
-  if (cached !== undefined) {
-    return cached;
-  }
-  const caseInsensitiveFilesystem = defaultCaseInsensitiveFilesystem();
-  filesystemCaseCache.set(parent, caseInsensitiveFilesystem);
-  return caseInsensitiveFilesystem;
+  return defaultCaseInsensitiveFilesystem();
 }
 
 export function assertInsideProjectRoot(projectRoot: string, candidatePath: string, label: string): void {
@@ -196,18 +170,6 @@ async function resolveMissingCanonicalParent(directoryPath: string): Promise<Can
     canonicalPath: resolvedParent.canonicalPath,
     missingSegments: [...resolvedParent.missingSegments, path.basename(directoryPath)]
   };
-}
-
-async function nearestExistingParent(directoryPath: string): Promise<string> {
-  const stats = await statIfExists(directoryPath);
-  if (stats?.isDirectory()) {
-    return realpath(directoryPath);
-  }
-  const parent = path.dirname(directoryPath);
-  if (parent === directoryPath) {
-    return directoryPath;
-  }
-  return nearestExistingParent(parent);
 }
 
 function normalizeReportPathForCollision(filePath: string, caseInsensitiveFilesystem: boolean): string {

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -1,0 +1,208 @@
+import { access, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface ReportPathTarget {
+  label: string;
+  path: string | undefined;
+}
+
+interface ResolvedReportPathTarget {
+  label: string;
+  path: string;
+  absolutePath: string;
+  collisionPath: string;
+}
+
+type FilesystemCaseCache = Map<string, boolean>;
+
+export async function validateReportPathTargets(
+  projectRoot: string,
+  targets: ReportPathTarget[]
+): Promise<void> {
+  const root = path.resolve(projectRoot);
+  const reportTargets = targets.filter((target): target is { label: string; path: string } => (
+    target.path !== undefined
+  ));
+  const shouldCheckCaseCollisions = reportTargets.length > 1;
+  const filesystemCaseCache: FilesystemCaseCache = new Map();
+  const resolvedTargets = await Promise.all(
+    reportTargets.map((target) => (
+      resolveReportPathTarget(root, target, shouldCheckCaseCollisions, filesystemCaseCache)
+    ))
+  );
+
+  for (let leftIndex = 0; leftIndex < resolvedTargets.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < resolvedTargets.length; rightIndex += 1) {
+      ensureDistinctReportPaths(resolvedTargets[leftIndex], resolvedTargets[rightIndex]);
+    }
+  }
+}
+
+async function resolveReportPathTarget(
+  projectRoot: string,
+  target: { label: string; path: string },
+  shouldCheckCaseCollisions: boolean,
+  filesystemCaseCache: FilesystemCaseCache
+): Promise<ResolvedReportPathTarget> {
+  const absolutePath = path.resolve(projectRoot, target.path);
+  if (isFilesystemRoot(absolutePath)) {
+    throw new Error(`${target.label} must target a report file, not a filesystem root`);
+  }
+  if (absolutePath === projectRoot) {
+    throw new Error(`${target.label} must target a report file, not the project root`);
+  }
+  if (!isInsidePath(projectRoot, absolutePath)) {
+    throw new Error(`${target.label} must stay inside the project root`);
+  }
+
+  const stats = await statIfExists(absolutePath);
+  if (stats?.isDirectory()) {
+    throw new Error(`${target.label} must target a report file, not an existing directory`);
+  }
+
+  const canonicalPath = await canonicalizeReportPath(absolutePath);
+  const canonicalRoot = await canonicalizeExistingParent(projectRoot);
+  if (!isInsidePath(canonicalRoot, canonicalPath)) {
+    throw new Error(`${target.label} must stay inside the project root`);
+  }
+
+  const caseInsensitiveFilesystem = shouldCheckCaseCollisions
+    ? await caseInsensitiveFilesystemForTarget(absolutePath, filesystemCaseCache)
+    : false;
+
+  return {
+    label: target.label,
+    path: target.path,
+    absolutePath,
+    collisionPath: normalizeReportPathForCollision(canonicalPath, caseInsensitiveFilesystem)
+  };
+}
+
+async function caseInsensitiveFilesystemForTarget(
+  absolutePath: string,
+  filesystemCaseCache: FilesystemCaseCache
+): Promise<boolean> {
+  const parent = await nearestExistingParent(path.dirname(absolutePath));
+  const cached = filesystemCaseCache.get(parent);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const caseInsensitiveFilesystem = await isCaseInsensitiveFilesystem(parent);
+  filesystemCaseCache.set(parent, caseInsensitiveFilesystem);
+  return caseInsensitiveFilesystem;
+}
+
+async function statIfExists(filePath: string): Promise<Awaited<ReturnType<typeof stat>> | undefined> {
+  try {
+    return await stat(filePath);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return errorCode(error) === "ENOENT";
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return undefined;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+async function canonicalizeReportPath(filePath: string): Promise<string> {
+  try {
+    return await realpath(filePath);
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+    return path.join(await canonicalizeExistingParent(path.dirname(filePath)), path.basename(filePath));
+  }
+}
+
+async function canonicalizeExistingParent(directoryPath: string): Promise<string> {
+  try {
+    return await realpath(directoryPath);
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+    const parent = path.dirname(directoryPath);
+    if (parent === directoryPath) {
+      return directoryPath;
+    }
+    return path.join(await canonicalizeExistingParent(parent), path.basename(directoryPath));
+  }
+}
+
+async function nearestExistingParent(directoryPath: string): Promise<string> {
+  const stats = await statIfExists(directoryPath);
+  if (stats?.isDirectory()) {
+    return realpath(directoryPath);
+  }
+  const parent = path.dirname(directoryPath);
+  if (parent === directoryPath) {
+    return directoryPath;
+  }
+  return nearestExistingParent(parent);
+}
+
+function normalizeReportPathForCollision(filePath: string, caseInsensitiveFilesystem: boolean): string {
+  const normalized = path.normalize(filePath);
+  return caseInsensitiveFilesystem ? normalized.toLowerCase() : normalized;
+}
+
+async function isCaseInsensitiveFilesystem(projectRoot: string): Promise<boolean> {
+  const probeDirectory = await createCaseProbeDirectory(projectRoot);
+  if (probeDirectory === undefined) {
+    return defaultCaseInsensitiveFilesystem();
+  }
+
+  try {
+    const probeFile = path.join(probeDirectory, "cognitive-typescript-case-probe");
+    await writeFile(probeFile, "");
+    await access(path.join(probeDirectory, "COGNITIVE-TYPESCRIPT-CASE-PROBE"));
+    return true;
+  } catch (error) {
+    return isMissingPathError(error) ? false : defaultCaseInsensitiveFilesystem();
+  } finally {
+    await rm(probeDirectory, { force: true, recursive: true });
+  }
+}
+
+function defaultCaseInsensitiveFilesystem(): boolean {
+  return process.platform === "win32" || process.platform === "darwin";
+}
+
+async function createCaseProbeDirectory(projectRoot: string): Promise<string | undefined> {
+  try {
+    return await mkdtemp(path.join(projectRoot, ".cognitive-typescript-case-"));
+  } catch {
+    return undefined;
+  }
+}
+
+function isFilesystemRoot(filePath: string): boolean {
+  const parsed = path.parse(filePath);
+  return path.resolve(filePath) === parsed.root;
+}
+
+function isInsidePath(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function ensureDistinctReportPaths(left: ResolvedReportPathTarget, right: ResolvedReportPathTarget): void {
+  if (left.collisionPath !== right.collisionPath) {
+    return;
+  }
+  throw new Error(
+    `${left.label} and ${right.label} must target different report files: ${left.path} and ${right.path}`
+  );
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,6 @@
 export type CliMode = "all" | "changed" | "explicit" | "help";
 export type ReportFormat = "toon" | "json" | "text" | "junit" | "none";
 export type ReportStatus = "passed" | "failed";
-export type MethodReportStatus = ReportStatus;
 
 export interface SourceSpan {
   startLine: number;
@@ -14,8 +13,13 @@ export interface Writer {
   write(chunk: string): unknown;
 }
 
-export interface CliArguments {
-  mode: CliMode;
+export interface HelpCliArguments {
+  mode: "help";
+  fileArgs: string[];
+}
+
+export interface AnalysisCliArguments {
+  mode: Exclude<CliMode, "help">;
   fileArgs: string[];
   format: ReportFormat;
   threshold: number;
@@ -25,6 +29,8 @@ export interface CliArguments {
   output?: string;
   junitReport?: string;
 }
+
+export type CliArguments = HelpCliArguments | AnalysisCliArguments;
 
 export interface MethodDescriptor {
   functionName: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,7 @@
 export type CliMode = "all" | "changed" | "explicit" | "help";
+export type ReportFormat = "toon" | "json" | "text" | "junit" | "none";
+export type ReportStatus = "passed" | "failed";
+export type MethodReportStatus = ReportStatus;
 
 export interface SourceSpan {
   startLine: number;
@@ -14,6 +17,13 @@ export interface Writer {
 export interface CliArguments {
   mode: CliMode;
   fileArgs: string[];
+  format: ReportFormat;
+  threshold: number;
+  agent: boolean;
+  failuresOnly: boolean;
+  omitRedundancy: boolean;
+  output?: string;
+  junitReport?: string;
 }
 
 export interface MethodDescriptor {
@@ -36,6 +46,7 @@ export interface AnalyzeProjectOptions {
   projectRoot?: string;
   explicitPaths?: string[];
   changedOnly?: boolean;
+  threshold?: number;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -43,6 +54,7 @@ export interface AnalyzeProjectOptions {
 export interface AnalysisResult {
   metrics: MethodMetrics[];
   maxCognitiveComplexity: number;
+  threshold: number;
   thresholdExceeded: boolean;
   selectedFiles: string[];
   warnings: string[];

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -47,6 +47,9 @@ describe("cli", () => {
     );
     expect(() => parseCliArguments(["--format"])).toThrow("--format requires a format");
     expect(() => parseCliArguments(["--format="])).toThrow("--format requires a format");
+    expect(() => parseCliArguments(["--format", "--agent"])).toThrow("--format requires a format");
+    expect(() => parseCliArguments(["--output", "--agent"])).toThrow("--output requires a path");
+    expect(() => parseCliArguments(["--threshold", "--agent"])).toThrow("--threshold requires a positive integer");
     expect(() => parseCliArguments(["--failures-only=True"])).toThrow(
       "--failures-only requires true or false when a value is provided"
     );
@@ -55,6 +58,15 @@ describe("cli", () => {
     );
     expect(() => parseCliArguments(["--threshold", "1.5"])).toThrow("--threshold requires a positive integer");
     expect(() => parseCliArguments(["--output="])).toThrow("--output requires a path");
+    expect(() => parseCliArguments(["--output", " reports/primary.json "])).toThrow(
+      "--output must not include leading or trailing whitespace"
+    );
+    expect(() => parseCliArguments(["--help", "--changed"])).toThrow(
+      "--help cannot be combined with other options or file arguments"
+    );
+    expect(() => parseCliArguments(["--help", "src"])).toThrow(
+      "--help cannot be combined with other options or file arguments"
+    );
   });
 
   it("applies agent defaults and explicit overrides", () => {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { parseCliArguments, runCli } from "../src/index";
-import { StringWriter, createTempDir, disposeTempDir, writeProjectFiles } from "./testUtils";
+import { StringWriter, createTempDir, disposeTempDir, readText, writeProjectFiles } from "./testUtils";
 
 const tempDirs: string[] = [];
 
@@ -11,12 +11,66 @@ afterEach(async () => {
 
 describe("cli", () => {
   it("parses help and changed modes", () => {
-    expect(parseCliArguments(["--help"])).toEqual({ mode: "help", fileArgs: [] });
-    expect(parseCliArguments(["--changed"])).toEqual({ mode: "changed", fileArgs: [] });
+    expect(parseCliArguments(["--help"])).toMatchObject({ mode: "help", fileArgs: [] });
+    expect(parseCliArguments(["--changed"])).toMatchObject({ mode: "changed", fileArgs: [] });
     expect(() => parseCliArguments(["--changed", "src"])).toThrow("--changed cannot be combined with file arguments");
   });
 
-  it("prints the no-files message for empty projects", async () => {
+  it("parses report controls and inline valued options", () => {
+    expect(parseCliArguments([
+      "--changed",
+      "--format=json",
+      "--agent",
+      "--failures-only=false",
+      "--omit-redundancy=false",
+      "--output",
+      "reports/primary.json",
+      "--junit-report=reports/junit.xml",
+      "--threshold",
+      "9"
+    ])).toEqual({
+      mode: "changed",
+      fileArgs: [],
+      format: "json",
+      threshold: 9,
+      agent: true,
+      failuresOnly: false,
+      omitRedundancy: false,
+      output: "reports/primary.json",
+      junitReport: "reports/junit.xml"
+    });
+  });
+
+  it("rejects duplicate options, strict boolean violations, and invalid thresholds", () => {
+    expect(() => parseCliArguments(["--format", "json", "--format=text"])).toThrow(
+      "--format can only be provided once"
+    );
+    expect(() => parseCliArguments(["--failures-only=True"])).toThrow(
+      "--failures-only requires true or false when a value is provided"
+    );
+    expect(() => parseCliArguments(["--omit-redundancy=yes"])).toThrow(
+      "--omit-redundancy requires true or false when a value is provided"
+    );
+    expect(() => parseCliArguments(["--threshold", "1.5"])).toThrow("--threshold requires a positive integer");
+    expect(() => parseCliArguments(["--output="])).toThrow("--output requires a path");
+  });
+
+  it("applies agent defaults and explicit overrides", () => {
+    expect(parseCliArguments(["--agent"])).toMatchObject({
+      format: "toon",
+      agent: true,
+      failuresOnly: true,
+      omitRedundancy: true
+    });
+    expect(parseCliArguments(["--agent", "--format=text", "--failures-only=false", "--omit-redundancy=false"]))
+      .toMatchObject({
+        format: "text",
+        failuresOnly: false,
+        omitRedundancy: false
+      });
+  });
+
+  it("prints an empty passed report for empty projects", async () => {
     const projectRoot = await createTempDir("cognitive-cli-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -28,7 +82,7 @@ describe("cli", () => {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toContain("No TypeScript files to analyze.");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 15\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 
@@ -40,6 +94,7 @@ describe("cli", () => {
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("Usage:");
+    expect(stdout.toString()).toContain("Exit codes:");
     expect(stderr.toString()).toBe("");
   });
 
@@ -69,6 +124,103 @@ describe("cli", () => {
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toContain("tooComplex");
     expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded: 28 > 15");
+  });
+
+  it("uses configured thresholds for exit code decisions", async () => {
+    const projectRoot = await createTempDir("cognitive-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `${buildDeepNestedIfFunction("tooComplex", 7)}`
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const exitCode = await runCli(["--threshold=30"], projectRoot, stdout, stderr);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.toString()).toContain("threshold: 30");
+    expect(stderr.toString()).toBe("");
+  });
+
+  it("writes primary output files and full JUnit sidecars", async () => {
+    const projectRoot = await createTempDir("cognitive-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `${buildDeepNestedIfFunction("tooComplex", 7)}
+
+export function safe(value: number): number {
+  return value + 1;
+}
+`
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const exitCode = await runCli([
+      "--format=json",
+      "--failures-only",
+      "--output=reports/primary.json",
+      "--junit-report",
+      "reports/junit.xml"
+    ], projectRoot, stdout, stderr);
+    const primary = JSON.parse(await readText(`${projectRoot}/reports/primary.json`)) as {
+      methods: Array<{ method: string }>;
+    };
+    const junit = await readText(`${projectRoot}/reports/junit.xml`);
+
+    expect(exitCode).toBe(2);
+    expect(stdout.toString()).toBe("");
+    expect(primary.methods).toEqual([expect.objectContaining({ method: "tooComplex" })]);
+    expect(junit).toContain('tests="2"');
+    expect(junit).toContain('name="tooComplex:1"');
+    expect(junit).toContain('name="safe:20"');
+    expect(junit).toContain("Cognitive Complexity: 28");
+    expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded");
+  });
+
+  it("writes empty primary files for none reports", async () => {
+    const projectRoot = await createTempDir("cognitive-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": "export function safe(value: number): number { return value + 1; }\n"
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const exitCode = await runCli([
+      "--format=none",
+      "--output=reports/empty.txt"
+    ], projectRoot, stdout, stderr);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.toString()).toBe("");
+    expect(await readText(`${projectRoot}/reports/empty.txt`)).toBe("");
+    expect(stderr.toString()).toBe("");
+  });
+
+  it("rejects report paths that escape or collide", async () => {
+    const projectRoot = await createTempDir("cognitive-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": "export function safe(value: number): number { return value + 1; }\n"
+    });
+
+    const escapeStdout = new StringWriter();
+    const escapeStderr = new StringWriter();
+    expect(await runCli(["--output=../outside.txt"], projectRoot, escapeStdout, escapeStderr)).toBe(1);
+    expect(escapeStderr.toString()).toContain("--output must stay inside the project root");
+
+    const collisionStdout = new StringWriter();
+    const collisionStderr = new StringWriter();
+    expect(await runCli([
+      "--output=reports/result.xml",
+      "--junit-report=reports/result.xml"
+    ], projectRoot, collisionStdout, collisionStderr)).toBe(1);
+    expect(collisionStderr.toString()).toContain("--output and --junit-report must target different report files");
   });
 });
 

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -11,7 +11,7 @@ afterEach(async () => {
 
 describe("cli", () => {
   it("parses help and changed modes", () => {
-    expect(parseCliArguments(["--help"])).toMatchObject({ mode: "help", fileArgs: [] });
+    expect(parseCliArguments(["--help"])).toEqual({ mode: "help", fileArgs: [] });
     expect(parseCliArguments(["--changed"])).toMatchObject({ mode: "changed", fileArgs: [] });
     expect(() => parseCliArguments(["--changed", "src"])).toThrow("--changed cannot be combined with file arguments");
   });
@@ -45,6 +45,8 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--format", "json", "--format=text"])).toThrow(
       "--format can only be provided once"
     );
+    expect(() => parseCliArguments(["--format"])).toThrow("--format requires a format");
+    expect(() => parseCliArguments(["--format="])).toThrow("--format requires a format");
     expect(() => parseCliArguments(["--failures-only=True"])).toThrow(
       "--failures-only requires true or false when a value is provided"
     );
@@ -105,8 +107,9 @@ describe("cli", () => {
     const exitCode = await runCli(["--changed", "src"], process.cwd(), stdout, stderr);
 
     expect(exitCode).toBe(1);
-    expect(stdout.toString()).toContain("Usage:");
+    expect(stdout.toString()).toBe("");
     expect(stderr.toString()).toContain("--changed cannot be combined with file arguments");
+    expect(stderr.toString()).toContain("Usage:");
   });
 
   it("returns exit code 2 when the threshold is exceeded", async () => {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -156,6 +156,12 @@ describe("report formatting", () => {
     expect(output).toContain("Source: src/quoted&amp;file.ts:1-3");
   });
 
+  it("rounds tiny positive JUnit elapsed times up to a visible non-zero value", () => {
+    const output = formatJunitReport(buildAnalysisReport([metric()]), false, Number.EPSILON);
+
+    expect(output).toContain('time="0.000001"');
+  });
+
   it("returns empty content for none reports after validating the threshold", () => {
     expect(formatAnalysisReport([metric()], { format: "none" })).toBe("");
     expect(() => formatAnalysisReport([], { format: "none", threshold: 0 })).toThrow(

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAgentAnalysisReport,
+  buildAnalysisReport,
+  formatAnalysisReport,
+  formatJunitReport,
+  formatTextReport,
+  formatToonReport,
+  sortMetrics
+} from "../src/report";
+import type { MethodMetrics } from "../src/types";
+
+function metric(overrides: Partial<MethodMetrics> = {}): MethodMetrics {
+  return {
+    functionName: "safe",
+    containerName: null,
+    displayName: "safe",
+    startLine: 1,
+    endLine: 3,
+    bodySpan: {
+      startLine: 1,
+      startColumn: 0,
+      endLine: 3,
+      endColumn: 1
+    },
+    cognitiveComplexity: 1,
+    filePath: "/repo/src/sample.ts",
+    relativePath: "src/sample.ts",
+    location: "src/sample.ts:1-3",
+    ...overrides
+  };
+}
+
+describe("report formatting", () => {
+  it("builds status and method entries from cognitive metrics", () => {
+    const report = buildAnalysisReport([
+      metric(),
+      metric({
+        displayName: "risky",
+        startLine: 5,
+        endLine: 10,
+        cognitiveComplexity: 16
+      })
+    ]);
+
+    expect(report.status).toBe("failed");
+    expect(report.threshold).toBe(15);
+    expect(report.methods).toEqual([
+      {
+        status: "failed",
+        cc: 16,
+        method: "risky",
+        src: "src/sample.ts",
+        lineStart: 5,
+        lineEnd: 10
+      },
+      {
+        status: "passed",
+        cc: 1,
+        method: "safe",
+        src: "src/sample.ts",
+        lineStart: 1,
+        lineEnd: 3
+      }
+    ]);
+  });
+
+  it("uses deterministic ordering by complexity, source, method, and line", () => {
+    const metrics = sortMetrics([
+      metric({ displayName: "b", relativePath: "src/b.ts", startLine: 9, cognitiveComplexity: 4 }),
+      metric({ displayName: "a", relativePath: "src/b.ts", startLine: 1, cognitiveComplexity: 4 }),
+      metric({ displayName: "z", relativePath: "src/a.ts", startLine: 5, cognitiveComplexity: 4 }),
+      metric({ displayName: "top", relativePath: "src/c.ts", startLine: 1, cognitiveComplexity: 9 })
+    ]);
+
+    expect(metrics.map((entry) => `${entry.relativePath}:${entry.displayName}:${entry.startLine}`)).toEqual([
+      "src/c.ts:top:1",
+      "src/a.ts:z:5",
+      "src/b.ts:a:1",
+      "src/b.ts:b:9"
+    ]);
+  });
+
+  it("formats JSON, text, and TOON reports with the cognitive-only model", () => {
+    const metrics = [metric({ displayName: "risky", cognitiveComplexity: 16 })];
+
+    expect(JSON.parse(formatAnalysisReport(metrics, { format: "json" }))).toEqual({
+      status: "failed",
+      threshold: 15,
+      methods: [
+        {
+          status: "failed",
+          cc: 16,
+          method: "risky",
+          src: "src/sample.ts",
+          lineStart: 1,
+          lineEnd: 3
+        }
+      ]
+    });
+    expect(formatTextReport(buildAnalysisReport(metrics))).toContain("| status | cc | method | src");
+    expect(formatToonReport(buildAnalysisReport(metrics))).toContain("methods[1]{status,cc,method,src,lineStart,lineEnd}:");
+  });
+
+  it("filters failures and omits redundant method status for compact primary reports", () => {
+    const parsed = JSON.parse(formatAnalysisReport([
+      metric(),
+      metric({ displayName: "risky", cognitiveComplexity: 16 })
+    ], {
+      format: "json",
+      failuresOnly: true,
+      omitRedundancy: true
+    })) as { status: string; threshold: number; methods: Array<Record<string, unknown>> };
+
+    expect(parsed.status).toBe("failed");
+    expect(parsed.threshold).toBe(15);
+    expect(parsed.methods).toEqual([
+      expect.objectContaining({
+        method: "risky",
+        cc: 16
+      })
+    ]);
+    expect(parsed.methods[0]).not.toHaveProperty("status");
+  });
+
+  it("uses agent as failures-only plus omit-redundancy defaults", () => {
+    const report = buildAgentAnalysisReport([
+      metric(),
+      metric({ displayName: "risky", cognitiveComplexity: 16 })
+    ]);
+    const parsed = JSON.parse(formatAnalysisReport([
+      metric(),
+      metric({ displayName: "risky", cognitiveComplexity: 16 })
+    ], {
+      format: "json",
+      agent: true
+    })) as typeof report;
+
+    expect(parsed).toEqual(report);
+    expect(parsed.methods).toHaveLength(1);
+    expect(parsed.methods[0]).not.toHaveProperty("status");
+  });
+
+  it("formats JUnit XML with elapsed time and failure diagnostics", () => {
+    const output = formatJunitReport(buildAnalysisReport([
+      metric({ displayName: "risky \"quoted\" <value>", relativePath: "src/quoted&file.ts", cognitiveComplexity: 16 })
+    ]), false, 0.25);
+
+    expect(output).toContain('<testsuites name="cognitive-typescript" tests="1" failures="1" skipped="0" errors="0" time="0.250000">');
+    expect(output).toContain('classname="src/quoted&amp;file.ts"');
+    expect(output).toContain('name="risky &quot;quoted&quot; &lt;value&gt;:1"');
+    expect(output).toContain('<property name="status" value="failed"/>');
+    expect(output).toContain("Cognitive Complexity: 16");
+    expect(output).toContain("Threshold: 15");
+    expect(output).toContain("Source: src/quoted&amp;file.ts:1-3");
+  });
+
+  it("returns empty content for none reports after validating the threshold", () => {
+    expect(formatAnalysisReport([metric()], { format: "none" })).toBe("");
+    expect(() => formatAnalysisReport([], { format: "none", threshold: 0 })).toThrow(
+      "Threshold must be a positive integer"
+    );
+  });
+});

--- a/packages/core/test/reportPaths.test.ts
+++ b/packages/core/test/reportPaths.test.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { validateReportPathTargets } from "../src/reportPaths";
+import { createTempDir, disposeTempDir, writeProjectFiles } from "./testUtils";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(disposeTempDir));
+});
+
+describe("reportPaths", () => {
+  it("accepts nested report files inside missing directories", async () => {
+    const projectRoot = await createTempDir("cognitive-report-paths-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}'
+    });
+
+    await expect(validateReportPathTargets(projectRoot, [
+      { label: "--output", path: "reports/nested/result.json" }
+    ])).resolves.toBeUndefined();
+  });
+
+  it("rejects project-root, filesystem-root, and directory targets", async () => {
+    const projectRoot = await createTempDir("cognitive-report-paths-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "reports/.gitkeep": ""
+    });
+
+    await expect(validateReportPathTargets(projectRoot, [
+      { label: "--output", path: "." }
+    ])).rejects.toThrow("--output must target a report file, not the project root");
+
+    await expect(validateReportPathTargets(projectRoot, [
+      { label: "--output", path: path.parse(projectRoot).root }
+    ])).rejects.toThrow("--output must target a report file, not a filesystem root");
+
+    await expect(validateReportPathTargets(projectRoot, [
+      { label: "--output", path: "reports" }
+    ])).rejects.toThrow("--output must target a report file, not an existing directory");
+  });
+});


### PR DESCRIPTION
## Summary
- add aligned CLI/core report formats, threshold controls, output path safety, JUnit sidecars, and agent defaults
- expose the report model from core and carry threshold and elapsed-time metadata through primary and JUnit output
- add tests for parsing, report formatting, output files, path validation, exit codes, and deterministic ordering

## Verification
- `npm run build`
- `npm test`
- `npm run cognitive-typescript-check`

Closes #17