### PR TITLE
Expose aligned Jest and Vitest reporter configuration

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,11 +1,9 @@
-import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 
 import { analyzeProject } from "./analyzeProject";
 import { COGNITIVE_COMPLEXITY_THRESHOLD, validateThreshold } from "./constants";
-import { formatAnalysisReport } from "./report";
-import { assertInsideProjectRoot, validateReportPathTargets } from "./reportPaths";
+import { publishAnalysisReports } from "./reportPublishing";
 import { writeLine } from "./utils";
 import type { AnalysisCliArguments, CliArguments, ReportFormat, Writer } from "./types";
 
@@ -368,13 +366,6 @@ export async function runCli(
     return 0;
   }
 
-  try {
-    await validateCliReportPaths(parsed, projectRoot);
-  } catch (error) {
-    writeLine(stderr, (error as Error).message);
-    return 1;
-  }
-
   const startedAt = performance.now();
   return handleCliResult(
     await analyzeCliProject(parsed, projectRoot, stderr),
@@ -445,40 +436,19 @@ async function writeCliReports(
   stdout: Writer,
   elapsedSeconds: number
 ): Promise<void> {
-  const primaryReport = formatAnalysisReport(result.metrics, {
+  await publishAnalysisReports({
+    projectRoot,
+    stdout,
+    metrics: result.metrics,
     format: parsed.format,
+    agent: parsed.agent,
     threshold: result.threshold,
     failuresOnly: parsed.failuresOnly,
     omitRedundancy: parsed.omitRedundancy,
+    output: parsed.output,
+    junitReport: parsed.junitReport,
     elapsedSeconds
   });
-  if (parsed.output) {
-    await writeReportFile(projectRoot, parsed.output, primaryReport);
-  } else if (primaryReport.length > 0) {
-    stdout.write(primaryReport);
-  }
-
-  if (parsed.junitReport) {
-    await writeReportFile(projectRoot, parsed.junitReport, formatAnalysisReport(result.metrics, {
-      format: "junit",
-      threshold: result.threshold,
-      elapsedSeconds
-    }));
-  }
-}
-
-async function validateCliReportPaths(parsed: AnalysisCliArguments, projectRoot: string): Promise<void> {
-  await validateReportPathTargets(projectRoot, [
-    { label: "--output", path: parsed.output },
-    { label: "--junit-report", path: parsed.junitReport }
-  ]);
-}
-
-async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {
-  const absolutePath = path.resolve(projectRoot, reportPath);
-  assertInsideProjectRoot(path.resolve(projectRoot), absolutePath, "Report path");
-  await mkdir(path.dirname(absolutePath), { recursive: true });
-  await writeFile(absolutePath, content);
 }
 
 function writeCliThresholdStatus(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,7 @@ export {
   sortMetrics
 } from "./report";
 export { deleteOwnedReportFile, publishAnalysisReports } from "./reportPublishing";
-export { resolveReporterReportOptions } from "./reporterOptions";
+export { DEFAULT_JUNIT_REPORT, resolveReporterReportOptions } from "./reporterOptions";
 export { validateReportPathTargets } from "./reportPaths";
 export {
   COGNITIVE_COMPLEXITY_THRESHOLD,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export {
   sortMetrics
 } from "./report";
 export { deleteOwnedReportFile, publishAnalysisReports } from "./reportPublishing";
+export { resolveReporterReportOptions } from "./reporterOptions";
 export { validateReportPathTargets } from "./reportPaths";
 export {
   COGNITIVE_COMPLEXITY_THRESHOLD,
@@ -28,7 +29,9 @@ export type {
   MethodDescriptor,
   MethodMetrics,
   PublishAnalysisReportsOptions,
+  ReporterReportOptions,
   ReportFormat,
+  ResolvedReporterReportOptions,
   ReportStatus,
   Writer
 } from "./types";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,8 @@ export {
   formatToonReport,
   sortMetrics
 } from "./report";
+export { deleteOwnedReportFile, publishAnalysisReports } from "./reportPublishing";
+export { validateReportPathTargets } from "./reportPaths";
 export {
   COGNITIVE_COMPLEXITY_THRESHOLD,
   NO_FILES_MESSAGE,
@@ -25,6 +27,7 @@ export type {
   HelpCliArguments,
   MethodDescriptor,
   MethodMetrics,
+  PublishAnalysisReportsOptions,
   ReportFormat,
   ReportStatus,
   Writer

--- a/packages/core/src/reportPublishing.ts
+++ b/packages/core/src/reportPublishing.ts
@@ -1,0 +1,55 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { formatAnalysisReport } from "./report";
+import { assertInsideProjectRoot, validateReportPathTargets } from "./reportPaths";
+import type { PublishAnalysisReportsOptions } from "./types";
+
+export async function publishAnalysisReports(options: PublishAnalysisReportsOptions): Promise<void> {
+  await validateReportPathTargets(options.projectRoot, [
+    { label: "--output", path: options.output },
+    { label: "--junit-report", path: options.junitReport }
+  ]);
+
+  const primaryReport = formatAnalysisReport(options.metrics, {
+    format: options.format,
+    agent: options.agent,
+    threshold: options.threshold,
+    failuresOnly: options.failuresOnly,
+    omitRedundancy: options.omitRedundancy,
+    elapsedSeconds: options.elapsedSeconds
+  });
+  if (options.output) {
+    await writeReportFile(options.projectRoot, options.output, primaryReport);
+  } else if (primaryReport.length > 0) {
+    options.stdout.write(primaryReport);
+  }
+
+  if (options.junitReport) {
+    await writeReportFile(
+      options.projectRoot,
+      options.junitReport,
+      formatAnalysisReport(options.metrics, {
+        format: "junit",
+        threshold: options.threshold,
+        elapsedSeconds: options.elapsedSeconds
+      })
+    );
+  }
+}
+
+export async function deleteOwnedReportFile(projectRoot: string, reportPath: string | undefined): Promise<void> {
+  if (!reportPath) {
+    return;
+  }
+  const absolutePath = path.resolve(projectRoot, reportPath);
+  assertInsideProjectRoot(path.resolve(projectRoot), absolutePath, "Report path");
+  await rm(absolutePath, { force: true });
+}
+
+async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {
+  const absolutePath = path.resolve(projectRoot, reportPath);
+  assertInsideProjectRoot(path.resolve(projectRoot), absolutePath, "Report path");
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content);
+}

--- a/packages/core/src/reportPublishing.ts
+++ b/packages/core/src/reportPublishing.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { formatAnalysisReport } from "./report";
@@ -42,8 +42,14 @@ export async function deleteOwnedReportFile(projectRoot: string, reportPath: str
   if (!reportPath) {
     return;
   }
+  const absoluteProjectRoot = path.resolve(projectRoot);
   const absolutePath = path.resolve(projectRoot, reportPath);
-  assertInsideProjectRoot(path.resolve(projectRoot), absolutePath, "Report path");
+  if (!isInsideProjectRoot(absoluteProjectRoot, absolutePath)) {
+    return;
+  }
+  if (!(await isOwnedJunitSidecar(absolutePath))) {
+    return;
+  }
   await rm(absolutePath, { force: true });
 }
 
@@ -52,4 +58,21 @@ async function writeReportFile(projectRoot: string, reportPath: string, content:
   assertInsideProjectRoot(path.resolve(projectRoot), absolutePath, "Report path");
   await mkdir(path.dirname(absolutePath), { recursive: true });
   await writeFile(absolutePath, content);
+}
+
+async function isOwnedJunitSidecar(reportPath: string): Promise<boolean> {
+  try {
+    const content = await readFile(reportPath, "utf8");
+    return content.includes("<testsuites") && content.includes('name="cognitive-typescript"');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isInsideProjectRoot(projectRoot: string, targetPath: string): boolean {
+  const relative = path.relative(projectRoot, targetPath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }

--- a/packages/core/src/reporterOptions.ts
+++ b/packages/core/src/reporterOptions.ts
@@ -1,0 +1,35 @@
+import { COGNITIVE_COMPLEXITY_THRESHOLD } from "./constants";
+import type { ReportFormat, ReporterReportOptions, ResolvedReporterReportOptions, Writer } from "./types";
+
+export function resolveReporterReportOptions(
+  options: ReporterReportOptions,
+  defaultJunitReport: string
+): ResolvedReporterReportOptions {
+  const agent = optionOr(options.agent, false);
+  return {
+    projectRoot: optionOr(options.projectRoot, process.cwd()),
+    paths: options.paths ?? [],
+    changedOnly: optionOr(options.changedOnly, false),
+    format: resolveFormat(options.format, agent),
+    agent,
+    failuresOnly: options.failuresOnly,
+    omitRedundancy: options.omitRedundancy,
+    output: options.output,
+    junit: optionOr(options.junit, true),
+    junitReport: optionOr(options.junitReport, defaultJunitReport),
+    threshold: optionOr(options.threshold, COGNITIVE_COMPLEXITY_THRESHOLD),
+    stdout: optionOr(options.stdout, process.stdout),
+    stderr: optionOr(options.stderr, process.stderr)
+  };
+}
+
+function resolveFormat(format: ReportFormat | undefined, agent: boolean): ReportFormat {
+  if (format !== undefined) {
+    return format;
+  }
+  return agent ? "toon" : "none";
+}
+
+function optionOr<T>(value: T | undefined, fallback: T): T {
+  return value ?? fallback;
+}

--- a/packages/core/src/reporterOptions.ts
+++ b/packages/core/src/reporterOptions.ts
@@ -1,11 +1,17 @@
+import path from "node:path";
+
 import { COGNITIVE_COMPLEXITY_THRESHOLD } from "./constants";
 import type { ReportFormat, ReporterReportOptions, ResolvedReporterReportOptions, Writer } from "./types";
 
+export const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
+
 export function resolveReporterReportOptions(
   options: ReporterReportOptions,
-  defaultJunitReport: string
+  defaultJunitReport: string = DEFAULT_JUNIT_REPORT
 ): ResolvedReporterReportOptions {
   const agent = optionOr(options.agent, false);
+  const output = resolvePathOption(options.output, "--output");
+  const junitReport = resolvePathOption(options.junitReport, "--junit-report") ?? defaultJunitReport;
   return {
     projectRoot: optionOr(options.projectRoot, process.cwd()),
     paths: options.paths ?? [],
@@ -14,9 +20,9 @@ export function resolveReporterReportOptions(
     agent,
     failuresOnly: options.failuresOnly,
     omitRedundancy: options.omitRedundancy,
-    output: options.output,
+    output,
     junit: optionOr(options.junit, true),
-    junitReport: optionOr(options.junitReport, defaultJunitReport),
+    junitReport,
     threshold: optionOr(options.threshold, COGNITIVE_COMPLEXITY_THRESHOLD),
     stdout: optionOr(options.stdout, process.stdout),
     stderr: optionOr(options.stderr, process.stderr)
@@ -32,4 +38,18 @@ function resolveFormat(format: ReportFormat | undefined, agent: boolean): Report
 
 function optionOr<T>(value: T | undefined, fallback: T): T {
   return value ?? fallback;
+}
+
+function resolvePathOption(value: string | undefined, option: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmedValue = value.trim();
+  if (trimmedValue === "") {
+    throw new Error(`${option} requires a path`);
+  }
+  if (trimmedValue !== value) {
+    throw new Error(`${option} must not include leading or trailing whitespace`);
+  }
+  return value;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,3 +65,17 @@ export interface AnalysisResult {
   selectedFiles: string[];
   warnings: string[];
 }
+
+export interface PublishAnalysisReportsOptions {
+  projectRoot: string;
+  stdout: Writer;
+  metrics: MethodMetrics[];
+  format: ReportFormat;
+  threshold: number;
+  agent?: boolean;
+  failuresOnly?: boolean;
+  omitRedundancy?: boolean;
+  output?: string;
+  junitReport?: string;
+  elapsedSeconds?: number;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,3 +79,35 @@ export interface PublishAnalysisReportsOptions {
   junitReport?: string;
   elapsedSeconds?: number;
 }
+
+export interface ReporterReportOptions {
+  projectRoot?: string;
+  changedOnly?: boolean;
+  paths?: string[];
+  format?: ReportFormat;
+  agent?: boolean;
+  failuresOnly?: boolean;
+  omitRedundancy?: boolean;
+  output?: string;
+  junit?: boolean;
+  junitReport?: string;
+  threshold?: number;
+  stdout?: Writer;
+  stderr?: Writer;
+}
+
+export interface ResolvedReporterReportOptions {
+  projectRoot: string;
+  paths: string[];
+  changedOnly: boolean;
+  format: ReportFormat;
+  agent: boolean;
+  failuresOnly: boolean | undefined;
+  omitRedundancy: boolean | undefined;
+  output: string | undefined;
+  junit: boolean;
+  junitReport: string;
+  threshold: number;
+  stdout: Writer;
+  stderr: Writer;
+}

--- a/packages/core/test/reportPublishing.test.ts
+++ b/packages/core/test/reportPublishing.test.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { deleteOwnedReportFile } from "../src";
+import { createTempDir, disposeTempDir } from "./testUtils";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(disposeTempDir));
+});
+
+describe("deleteOwnedReportFile", () => {
+  it("removes owned cognitive-typescript junit sidecars inside the project root", async () => {
+    const projectRoot = await createProjectRoot();
+    const reportPath = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
+    const absolutePath = path.join(projectRoot, reportPath);
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    await writeFile(
+      absolutePath,
+      '<?xml version="1.0" encoding="UTF-8"?><testsuites name="cognitive-typescript"></testsuites>'
+    );
+
+    await deleteOwnedReportFile(projectRoot, reportPath);
+
+    expect(existsSync(absolutePath)).toBe(false);
+  });
+
+  it("keeps files that are not junit reports", async () => {
+    const projectRoot = await createProjectRoot();
+    const reportPath = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
+    const absolutePath = path.join(projectRoot, reportPath);
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, "plain text");
+
+    await deleteOwnedReportFile(projectRoot, reportPath);
+
+    expect(existsSync(absolutePath)).toBe(true);
+  });
+
+  it("keeps junit reports that are not owned by cognitive-typescript", async () => {
+    const projectRoot = await createProjectRoot();
+    const reportPath = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
+    const absolutePath = path.join(projectRoot, reportPath);
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    await writeFile(
+      absolutePath,
+      '<?xml version="1.0" encoding="UTF-8"?><testsuites name="other-tool"></testsuites>'
+    );
+
+    await deleteOwnedReportFile(projectRoot, reportPath);
+
+    expect(existsSync(absolutePath)).toBe(true);
+  });
+
+  it("ignores missing files", async () => {
+    const projectRoot = await createProjectRoot();
+
+    await expect(deleteOwnedReportFile(projectRoot, "reports/missing.xml")).resolves.toBeUndefined();
+  });
+
+  it("ignores paths outside the project root", async () => {
+    const projectRoot = await createProjectRoot();
+    const externalReport = path.join(projectRoot, "..", "outside-junit.xml");
+    await writeFile(
+      externalReport,
+      '<?xml version="1.0" encoding="UTF-8"?><testsuites name="cognitive-typescript"></testsuites>'
+    );
+
+    await deleteOwnedReportFile(projectRoot, "../outside-junit.xml");
+
+    expect(existsSync(externalReport)).toBe(true);
+  });
+});
+
+async function createProjectRoot(): Promise<string> {
+  const projectRoot = await createTempDir("cognitive-typescript-report-publishing-");
+  tempDirs.push(projectRoot);
+  return projectRoot;
+}

--- a/packages/core/test/reporterOptions.test.ts
+++ b/packages/core/test/reporterOptions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_JUNIT_REPORT, resolveReporterReportOptions } from "../src/reporterOptions";
+
+describe("resolveReporterReportOptions", () => {
+  it("uses the shared default junit report path", () => {
+    expect(resolveReporterReportOptions({}).junitReport).toBe(DEFAULT_JUNIT_REPORT);
+  });
+
+  it("rejects empty output paths like the CLI", () => {
+    expect(() => resolveReporterReportOptions({ output: "" })).toThrow("--output requires a path");
+    expect(() => resolveReporterReportOptions({ output: " reports/out.json" })).toThrow(
+      "--output must not include leading or trailing whitespace"
+    );
+  });
+
+  it("rejects empty junit report paths like the CLI", () => {
+    expect(() => resolveReporterReportOptions({ junitReport: "" })).toThrow("--junit-report requires a path");
+    expect(() => resolveReporterReportOptions({ junitReport: " reports/junit.xml" })).toThrow(
+      "--junit-report must not include leading or trailing whitespace"
+    );
+  });
+});

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,17 +1,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-import type { Writer } from "@barney-media/cognitive-typescript-core";
-
-import CognitiveTypescriptJestReporter from "./reporter";
-
-export interface CognitiveTypescriptJestOptions {
-  projectRoot?: string;
-  changedOnly?: boolean;
-  paths?: string[];
-  stdout?: Writer;
-  stderr?: Writer;
-}
+import CognitiveTypescriptJestReporter, { type CognitiveTypescriptJestOptions } from "./reporter";
 
 type JestReporterEntry = string | [string, unknown];
 
@@ -31,6 +21,7 @@ export function withCognitiveTypescriptJest(
 }
 
 export { CognitiveTypescriptJestReporter };
+export type { CognitiveTypescriptJestOptions };
 export default CognitiveTypescriptJestReporter;
 
 function asArray<T>(value: T[] | T | undefined): T[] {

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -1,16 +1,28 @@
+import path from "node:path";
+
 import {
   analyzeProject,
   COGNITIVE_COMPLEXITY_THRESHOLD,
-  formatReport,
+  deleteOwnedReportFile,
   NO_ANALYZABLE_FUNCTIONS_MESSAGE,
-  NO_FILES_MESSAGE
+  NO_FILES_MESSAGE,
+  publishAnalysisReports,
+  validateReportPathTargets
 } from "@barney-media/cognitive-typescript-core";
-import type { Writer } from "@barney-media/cognitive-typescript-core";
+import type { ReportFormat, Writer } from "@barney-media/cognitive-typescript-core";
 
 export interface CognitiveTypescriptJestOptions {
   projectRoot?: string;
   changedOnly?: boolean;
   paths?: string[];
+  format?: ReportFormat;
+  agent?: boolean;
+  failuresOnly?: boolean;
+  omitRedundancy?: boolean;
+  output?: string;
+  junit?: boolean;
+  junitReport?: string;
+  threshold?: number;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -19,9 +31,19 @@ interface ResolvedReporterOptions {
   projectRoot: string;
   paths: string[];
   changedOnly: boolean;
+  format: ReportFormat;
+  agent: boolean;
+  failuresOnly: boolean | undefined;
+  omitRedundancy: boolean | undefined;
+  output: string | undefined;
+  junit: boolean;
+  junitReport: string;
+  threshold: number;
   stdout: Writer;
   stderr: Writer;
 }
+
+const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
 
 export default class CognitiveTypescriptJestReporter {
   private error: Error | undefined;
@@ -46,10 +68,19 @@ export default class CognitiveTypescriptJestReporter {
   private async finalize(): Promise<void> {
     const options = resolveReporterOptions(this.options);
     try {
+      await validateReportPathTargets(options.projectRoot, [
+        { label: "--output", path: options.output },
+        { label: "--junit-report", path: options.junitReport }
+      ]);
+      if (!options.junit) {
+        await deleteOwnedReportFile(options.projectRoot, options.junitReport);
+      }
+
       const result = await analyzeProject({
         projectRoot: options.projectRoot,
         explicitPaths: options.paths,
-        changedOnly: options.changedOnly
+        changedOnly: options.changedOnly,
+        threshold: options.threshold
       });
 
       if (result.selectedFiles.length === 0) {
@@ -61,13 +92,24 @@ export default class CognitiveTypescriptJestReporter {
         return;
       }
 
-      options.stdout.write(`${formatReport(result.metrics)}\n`);
+      await publishAnalysisReports({
+        projectRoot: options.projectRoot,
+        stdout: options.stdout,
+        metrics: result.metrics,
+        format: options.format,
+        agent: options.agent,
+        threshold: result.threshold,
+        failuresOnly: options.failuresOnly,
+        omitRedundancy: options.omitRedundancy,
+        output: options.output,
+        junitReport: options.junit ? options.junitReport : undefined
+      });
       if (result.thresholdExceeded) {
-        this.error = new Error(
-          `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${COGNITIVE_COMPLEXITY_THRESHOLD}`
+        const thresholdError = new Error(
+          `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${result.threshold}`
         );
-        options.stderr.write(`${this.error.message}\n`);
-        process.exitCode = 1;
+        options.stderr.write(`${thresholdError.message}\n`);
+        process.exitCode = 2;
       }
     } catch (error) {
       this.error = toError(error);
@@ -78,10 +120,19 @@ export default class CognitiveTypescriptJestReporter {
 }
 
 function resolveReporterOptions(options: CognitiveTypescriptJestOptions): ResolvedReporterOptions {
+  const agent = options.agent ?? false;
   return {
     projectRoot: options.projectRoot ?? process.cwd(),
     paths: options.paths ?? [],
     changedOnly: options.changedOnly ?? false,
+    format: options.format ?? (agent ? "toon" : "none"),
+    agent,
+    failuresOnly: options.failuresOnly,
+    omitRedundancy: options.omitRedundancy,
+    output: options.output,
+    junit: options.junit ?? true,
+    junitReport: options.junitReport ?? DEFAULT_JUNIT_REPORT,
+    threshold: options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD,
     stdout: options.stdout ?? process.stdout,
     stderr: options.stderr ?? process.stderr
   };

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -2,14 +2,14 @@ import path from "node:path";
 
 import {
   analyzeProject,
-  COGNITIVE_COMPLEXITY_THRESHOLD,
   deleteOwnedReportFile,
   NO_ANALYZABLE_FUNCTIONS_MESSAGE,
   NO_FILES_MESSAGE,
   publishAnalysisReports,
+  resolveReporterReportOptions,
   validateReportPathTargets
 } from "@barney-media/cognitive-typescript-core";
-import type { ReportFormat, Writer } from "@barney-media/cognitive-typescript-core";
+import type { ReportFormat, ResolvedReporterReportOptions, Writer } from "@barney-media/cognitive-typescript-core";
 
 export interface CognitiveTypescriptJestOptions {
   projectRoot?: string;
@@ -25,22 +25,6 @@ export interface CognitiveTypescriptJestOptions {
   threshold?: number;
   stdout?: Writer;
   stderr?: Writer;
-}
-
-interface ResolvedReporterOptions {
-  projectRoot: string;
-  paths: string[];
-  changedOnly: boolean;
-  format: ReportFormat;
-  agent: boolean;
-  failuresOnly: boolean | undefined;
-  omitRedundancy: boolean | undefined;
-  output: string | undefined;
-  junit: boolean;
-  junitReport: string;
-  threshold: number;
-  stdout: Writer;
-  stderr: Writer;
 }
 
 const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
@@ -119,23 +103,8 @@ export default class CognitiveTypescriptJestReporter {
   }
 }
 
-function resolveReporterOptions(options: CognitiveTypescriptJestOptions): ResolvedReporterOptions {
-  const agent = options.agent ?? false;
-  return {
-    projectRoot: options.projectRoot ?? process.cwd(),
-    paths: options.paths ?? [],
-    changedOnly: options.changedOnly ?? false,
-    format: options.format ?? (agent ? "toon" : "none"),
-    agent,
-    failuresOnly: options.failuresOnly,
-    omitRedundancy: options.omitRedundancy,
-    output: options.output,
-    junit: options.junit ?? true,
-    junitReport: options.junitReport ?? DEFAULT_JUNIT_REPORT,
-    threshold: options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD,
-    stdout: options.stdout ?? process.stdout,
-    stderr: options.stderr ?? process.stderr
-  };
+function resolveReporterOptions(options: CognitiveTypescriptJestOptions): ResolvedReporterReportOptions {
+  return resolveReporterReportOptions(options, DEFAULT_JUNIT_REPORT);
 }
 
 function toError(error: unknown): Error {

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -1,7 +1,6 @@
-import path from "node:path";
-
 import {
   analyzeProject,
+  DEFAULT_JUNIT_REPORT,
   deleteOwnedReportFile,
   NO_ANALYZABLE_FUNCTIONS_MESSAGE,
   NO_FILES_MESSAGE,
@@ -9,25 +8,9 @@ import {
   resolveReporterReportOptions,
   validateReportPathTargets
 } from "@barney-media/cognitive-typescript-core";
-import type { ReportFormat, ResolvedReporterReportOptions, Writer } from "@barney-media/cognitive-typescript-core";
+import type { ReporterReportOptions, ResolvedReporterReportOptions } from "@barney-media/cognitive-typescript-core";
 
-export interface CognitiveTypescriptJestOptions {
-  projectRoot?: string;
-  changedOnly?: boolean;
-  paths?: string[];
-  format?: ReportFormat;
-  agent?: boolean;
-  failuresOnly?: boolean;
-  omitRedundancy?: boolean;
-  output?: string;
-  junit?: boolean;
-  junitReport?: string;
-  threshold?: number;
-  stdout?: Writer;
-  stderr?: Writer;
-}
-
-const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
+export interface CognitiveTypescriptJestOptions extends ReporterReportOptions {}
 
 export default class CognitiveTypescriptJestReporter {
   private error: Error | undefined;

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -54,7 +54,7 @@ export default class CognitiveTypescriptJestReporter {
     try {
       await validateReportPathTargets(options.projectRoot, [
         { label: "--output", path: options.output },
-        { label: "--junit-report", path: options.junitReport }
+        { label: "--junit-report", path: options.junit ? options.junitReport : undefined }
       ]);
       if (!options.junit) {
         await deleteOwnedReportFile(options.projectRoot, options.junitReport);
@@ -89,10 +89,9 @@ export default class CognitiveTypescriptJestReporter {
         junitReport: options.junit ? options.junitReport : undefined
       });
       if (result.thresholdExceeded) {
-        const thresholdError = new Error(
-          `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${result.threshold}`
+        options.stderr.write(
+          `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${result.threshold}\n`
         );
-        options.stderr.write(`${thresholdError.message}\n`);
         process.exitCode = 2;
       }
     } catch (error) {

--- a/packages/jest/test/config.test.ts
+++ b/packages/jest/test/config.test.ts
@@ -23,4 +23,26 @@ describe("withCognitiveTypescriptJest", () => {
       [expect.any(String), {}]
     ]);
   });
+
+  it("forwards configured reporter options without mutating coverage settings", () => {
+    const options = {
+      format: "json" as const,
+      junit: false,
+      threshold: 9
+    };
+    const config = withCognitiveTypescriptJest(
+      {
+        collectCoverage: true,
+        coverageDirectory: "coverage"
+      },
+      options
+    );
+
+    expect(config.collectCoverage).toBe(true);
+    expect(config.coverageDirectory).toBe("coverage");
+    expect(config.reporters).toEqual([
+      "default",
+      [expect.any(String), options]
+    ]);
+  });
 });

--- a/packages/jest/test/integration.test.ts
+++ b/packages/jest/test/integration.test.ts
@@ -46,7 +46,7 @@ module.exports = withCognitiveTypescriptJest(
       projectRoot
     );
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(2);
     expect(`${result.stdout}\n${result.stderr}`).toContain("Cognitive Complexity threshold exceeded");
   });
 });

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { NO_ANALYZABLE_FUNCTIONS_MESSAGE } from "@barney-media/cognitive-typescript-core";
 import { StringWriter, createTempDir, disposeTempDir, writeProjectFiles } from "../../core/test/testUtils";
 import CognitiveTypescriptJestReporter from "../src/reporter";
 
@@ -39,6 +40,27 @@ describe("CognitiveTypescriptJestReporter", () => {
     await reporter.onRunComplete();
 
     expect(stdout.toString()).toContain("No TypeScript files to analyze.");
+    expect(stderr.toString()).toBe("");
+    expect(reporter.getLastError()).toBeUndefined();
+  });
+
+  it("prints the no-analyzable-functions message when selected files contain declarations only", async () => {
+    const projectRoot = await createProject({
+      "src/types.ts": "export interface Sample { value: string; }"
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptJestReporter(undefined, {
+      projectRoot,
+      paths: ["src"],
+      stdout,
+      stderr
+    });
+
+    await reporter.onRunComplete();
+
+    expect(stdout.toString()).toContain(NO_ANALYZABLE_FUNCTIONS_MESSAGE);
     expect(stderr.toString()).toBe("");
     expect(reporter.getLastError()).toBeUndefined();
   });
@@ -147,7 +169,10 @@ describe("CognitiveTypescriptJestReporter", () => {
       "src/sample.ts": buildSimpleFunction("safe")
     });
     await mkdir(path.dirname(path.join(projectRoot, DEFAULT_JUNIT_REPORT)), { recursive: true });
-    await writeFile(path.join(projectRoot, DEFAULT_JUNIT_REPORT), "stale");
+    await writeFile(
+      path.join(projectRoot, DEFAULT_JUNIT_REPORT),
+      '<?xml version="1.0" encoding="UTF-8"?><testsuites name="cognitive-typescript"></testsuites>'
+    );
 
     const reporter = new CognitiveTypescriptJestReporter(undefined, {
       projectRoot,
@@ -162,6 +187,30 @@ describe("CognitiveTypescriptJestReporter", () => {
     await reporter.onRunComplete();
 
     expect(existsSync(path.join(projectRoot, DEFAULT_JUNIT_REPORT))).toBe(false);
+    expect(await readText(path.join(projectRoot, "reports", "primary.json"))).toContain('"status": "passed"');
+  });
+
+  it("does not validate or delete unrelated junit paths when junit is disabled", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
+    });
+    const externalReport = path.join(projectRoot, "..", "outside-junit.xml");
+    await writeFile(externalReport, "unrelated");
+
+    const reporter = new CognitiveTypescriptJestReporter(undefined, {
+      projectRoot,
+      paths: ["src"],
+      format: "json",
+      output: "reports/primary.json",
+      junit: false,
+      junitReport: "../outside-junit.xml",
+      stdout: new StringWriter(),
+      stderr: new StringWriter()
+    });
+
+    await reporter.onRunComplete();
+
+    expect(await readText(externalReport)).toBe("unrelated");
     expect(await readText(path.join(projectRoot, "reports", "primary.json"))).toContain('"status": "passed"');
   });
 

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -1,9 +1,14 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { StringWriter, createTempDir, disposeTempDir, writeProjectFiles } from "../../core/test/testUtils";
 import CognitiveTypescriptJestReporter from "../src/reporter";
 
 const tempDirs: string[] = [];
+const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
 let originalExitCode: number | undefined;
 
 beforeEach(() => {
@@ -38,12 +43,9 @@ describe("CognitiveTypescriptJestReporter", () => {
     expect(reporter.getLastError()).toBeUndefined();
   });
 
-  it("stores the threshold error when the project exceeds the limit", async () => {
-    const projectRoot = await createTempDir("cognitive-jest-reporter-");
-    tempDirs.push(projectRoot);
-    await writeProjectFiles(projectRoot, {
-      "package.json": '{"name":"fixture","private":true}',
-      "src/sample.ts": `${buildDeepNestedIfFunction("tooComplex", 7)}`
+  it("writes only the default JUnit sidecar with default report controls", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
     });
 
     const stdout = new StringWriter();
@@ -57,12 +59,177 @@ describe("CognitiveTypescriptJestReporter", () => {
 
     await reporter.onRunComplete();
 
-    expect(stdout.toString()).toContain("tooComplex");
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe("");
+    const junit = await readText(path.join(projectRoot, DEFAULT_JUNIT_REPORT));
+    expect(junit).toContain("<testsuites");
+    expect(junit).toContain('classname="src/sample.ts"');
+    expect(junit).toContain('<property name="status" value="passed"/>');
+  });
+
+  it("writes configured primary and JUnit reports through the shared pipeline", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptJestReporter(undefined, {
+      projectRoot,
+      paths: ["src"],
+      format: "json",
+      agent: true,
+      failuresOnly: false,
+      omitRedundancy: true,
+      output: "reports/primary.json",
+      junit: true,
+      junitReport: "reports/custom-junit.xml",
+      threshold: 9,
+      stdout,
+      stderr
+    });
+
+    await reporter.onRunComplete();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe("");
+    const primary = JSON.parse(await readText(path.join(projectRoot, "reports", "primary.json"))) as {
+      threshold: number;
+      methods: Array<Record<string, unknown>>;
+    };
+    expect(primary.threshold).toBe(9);
+    expect(primary.methods).toEqual([
+      expect.objectContaining({
+        method: "safe"
+      })
+    ]);
+    expect(primary.methods[0]).not.toHaveProperty("status");
+    expect(existsSync(path.join(projectRoot, DEFAULT_JUNIT_REPORT))).toBe(false);
+    const junit = await readText(path.join(projectRoot, "reports", "custom-junit.xml"));
+    expect(junit).toContain('classname="src/sample.ts"');
+    expect(junit).toContain('<property name="status" value="passed"/>');
+  });
+
+  it("lets explicit agent overrides keep full output", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": `${buildSimpleFunction("safe")}\n\n${buildDeepNestedIfFunction("tooComplex", 7)}`
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptJestReporter(undefined, {
+      projectRoot,
+      paths: ["src"],
+      format: "json",
+      agent: true,
+      failuresOnly: false,
+      omitRedundancy: false,
+      stdout,
+      stderr
+    });
+
+    await reporter.onRunComplete();
+
+    const primary = JSON.parse(stdout.toString()) as {
+      methods: Array<Record<string, unknown>>;
+    };
+    expect(primary.methods).toHaveLength(2);
+    expect(primary.methods).toEqual(expect.arrayContaining([
+      expect.objectContaining({ method: "safe", status: "passed" }),
+      expect.objectContaining({ method: "tooComplex", status: "failed" })
+    ]));
     expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded");
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("suppresses and cleans the JUnit sidecar when junit is disabled", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
+    });
+    await mkdir(path.dirname(path.join(projectRoot, DEFAULT_JUNIT_REPORT)), { recursive: true });
+    await writeFile(path.join(projectRoot, DEFAULT_JUNIT_REPORT), "stale");
+
+    const reporter = new CognitiveTypescriptJestReporter(undefined, {
+      projectRoot,
+      paths: ["src"],
+      format: "json",
+      output: "reports/primary.json",
+      junit: false,
+      stdout: new StringWriter(),
+      stderr: new StringWriter()
+    });
+
+    await reporter.onRunComplete();
+
+    expect(existsSync(path.join(projectRoot, DEFAULT_JUNIT_REPORT))).toBe(false);
+    expect(await readText(path.join(projectRoot, "reports", "primary.json"))).toContain('"status": "passed"');
+  });
+
+  it("reports invalid report paths as configuration errors", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptJestReporter(undefined, {
+      projectRoot,
+      paths: ["src"],
+      output: "../outside.json",
+      stdout,
+      stderr
+    });
+
+    await reporter.onRunComplete();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toContain("--output must stay inside the project root");
     expect(reporter.getLastError()).toBeInstanceOf(Error);
     expect(process.exitCode).toBe(1);
   });
+
+  it("stores the threshold error and exits with code 2 when the project exceeds the limit", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildDeepNestedIfFunction("tooComplex", 7)
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptJestReporter(undefined, {
+      projectRoot,
+      paths: ["src"],
+      format: "text",
+      stdout,
+      stderr
+    });
+
+    await reporter.onRunComplete();
+
+    expect(stdout.toString()).toContain("tooComplex");
+    expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded");
+    expect(reporter.getLastError()).toBeUndefined();
+    expect(process.exitCode).toBe(2);
+  });
 });
+
+async function createProject(files: Record<string, string>): Promise<string> {
+  const projectRoot = await createTempDir("cognitive-jest-reporter-");
+  tempDirs.push(projectRoot);
+  await writeProjectFiles(projectRoot, {
+    "package.json": '{"name":"fixture","private":true}',
+    ...files
+  });
+  return projectRoot;
+}
+
+function buildSimpleFunction(name: string): string {
+  return `export function ${name}(value: boolean): number {
+  if (value) {
+    return 1;
+  }
+  return 0;
+}`;
+}
 
 function buildDeepNestedIfFunction(name: string, depth: number): string {
   const parameters = Array.from({ length: depth }, (_value, index) => `flag${index + 1}: boolean`).join(", ");
@@ -80,4 +247,8 @@ function buildDeepNestedIfFunction(name: string, depth: number): string {
   lines.push("  return 0;");
   lines.push("}");
   return lines.join("\n");
+}
+
+async function readText(filePath: string): Promise<string> {
+  return readFile(filePath, "utf8");
 }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -65,7 +65,7 @@ export class CognitiveTypescriptVitestReporter {
     try {
       await validateReportPathTargets(options.projectRoot, [
         { label: "--output", path: options.output },
-        { label: "--junit-report", path: options.junitReport }
+        { label: "--junit-report", path: options.junit ? options.junitReport : undefined }
       ]);
       if (!options.junit) {
         await deleteOwnedReportFile(options.projectRoot, options.junitReport);

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,11 +1,15 @@
+import path from "node:path";
+
 import {
   analyzeProject,
   COGNITIVE_COMPLEXITY_THRESHOLD,
-  formatReport,
+  deleteOwnedReportFile,
   NO_ANALYZABLE_FUNCTIONS_MESSAGE,
-  NO_FILES_MESSAGE
+  NO_FILES_MESSAGE,
+  publishAnalysisReports,
+  validateReportPathTargets
 } from "@barney-media/cognitive-typescript-core";
-import type { Writer } from "@barney-media/cognitive-typescript-core";
+import type { ReportFormat, Writer } from "@barney-media/cognitive-typescript-core";
 
 type VitestReporterEntry = string | [string, unknown] | {
   onTestRunEnd?: () => Promise<void>;
@@ -22,6 +26,14 @@ export interface CognitiveTypescriptVitestOptions {
   projectRoot?: string;
   changedOnly?: boolean;
   paths?: string[];
+  format?: ReportFormat;
+  agent?: boolean;
+  failuresOnly?: boolean;
+  omitRedundancy?: boolean;
+  output?: string;
+  junit?: boolean;
+  junitReport?: string;
+  threshold?: number;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -30,9 +42,19 @@ interface ResolvedReporterOptions {
   projectRoot: string;
   paths: string[];
   changedOnly: boolean;
+  format: ReportFormat;
+  agent: boolean;
+  failuresOnly: boolean | undefined;
+  omitRedundancy: boolean | undefined;
+  output: string | undefined;
+  junit: boolean;
+  junitReport: string;
+  threshold: number;
   stdout: Writer;
   stderr: Writer;
 }
+
+const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
 
 export class CognitiveTypescriptVitestReporter {
   private finalizePromise: Promise<void> | null = null;
@@ -56,26 +78,51 @@ export class CognitiveTypescriptVitestReporter {
 
   private async finalize(): Promise<void> {
     const options = resolveReporterOptions(this.options);
-    const result = await analyzeProject({
-      projectRoot: options.projectRoot,
-      explicitPaths: options.paths,
-      changedOnly: options.changedOnly
-    });
+    try {
+      await validateReportPathTargets(options.projectRoot, [
+        { label: "--output", path: options.output },
+        { label: "--junit-report", path: options.junitReport }
+      ]);
+      if (!options.junit) {
+        await deleteOwnedReportFile(options.projectRoot, options.junitReport);
+      }
 
-    if (result.selectedFiles.length === 0) {
-      options.stdout.write(`${NO_FILES_MESSAGE}\n`);
-      return;
-    }
-    if (result.metrics.length === 0) {
-      options.stdout.write(`${NO_ANALYZABLE_FUNCTIONS_MESSAGE}\n`);
-      return;
-    }
+      const result = await analyzeProject({
+        projectRoot: options.projectRoot,
+        explicitPaths: options.paths,
+        changedOnly: options.changedOnly,
+        threshold: options.threshold
+      });
 
-    options.stdout.write(`${formatReport(result.metrics)}\n`);
-    if (result.thresholdExceeded) {
-      options.stderr.write(
-        `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${COGNITIVE_COMPLEXITY_THRESHOLD}\n`
-      );
+      if (result.selectedFiles.length === 0) {
+        options.stdout.write(`${NO_FILES_MESSAGE}\n`);
+        return;
+      }
+      if (result.metrics.length === 0) {
+        options.stdout.write(`${NO_ANALYZABLE_FUNCTIONS_MESSAGE}\n`);
+        return;
+      }
+
+      await publishAnalysisReports({
+        projectRoot: options.projectRoot,
+        stdout: options.stdout,
+        metrics: result.metrics,
+        format: options.format,
+        agent: options.agent,
+        threshold: result.threshold,
+        failuresOnly: options.failuresOnly,
+        omitRedundancy: options.omitRedundancy,
+        output: options.output,
+        junitReport: options.junit ? options.junitReport : undefined
+      });
+      if (result.thresholdExceeded) {
+        options.stderr.write(
+          `Cognitive Complexity threshold exceeded: ${result.maxCognitiveComplexity} > ${result.threshold}\n`
+        );
+        process.exitCode = 2;
+      }
+    } catch (error) {
+      options.stderr.write(`${toError(error).message}\n`);
       process.exitCode = 1;
     }
   }
@@ -99,10 +146,19 @@ export function withCognitiveTypescriptVitest(
 }
 
 function resolveReporterOptions(options: CognitiveTypescriptVitestOptions): ResolvedReporterOptions {
+  const agent = options.agent ?? false;
   return {
     projectRoot: options.projectRoot ?? process.cwd(),
     paths: options.paths ?? [],
     changedOnly: options.changedOnly ?? false,
+    format: options.format ?? (agent ? "toon" : "none"),
+    agent,
+    failuresOnly: options.failuresOnly,
+    omitRedundancy: options.omitRedundancy,
+    output: options.output,
+    junit: options.junit ?? true,
+    junitReport: options.junitReport ?? DEFAULT_JUNIT_REPORT,
+    threshold: options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD,
     stdout: options.stdout ?? process.stdout,
     stderr: options.stderr ?? process.stderr
   };
@@ -123,4 +179,8 @@ function ensureDefaultReporter(existing: VitestReporterEntry[]): VitestReporterE
     return ["default", ...existing];
   }
   return existing;
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -2,14 +2,14 @@ import path from "node:path";
 
 import {
   analyzeProject,
-  COGNITIVE_COMPLEXITY_THRESHOLD,
   deleteOwnedReportFile,
   NO_ANALYZABLE_FUNCTIONS_MESSAGE,
   NO_FILES_MESSAGE,
   publishAnalysisReports,
+  resolveReporterReportOptions,
   validateReportPathTargets
 } from "@barney-media/cognitive-typescript-core";
-import type { ReportFormat, Writer } from "@barney-media/cognitive-typescript-core";
+import type { ReportFormat, ResolvedReporterReportOptions, Writer } from "@barney-media/cognitive-typescript-core";
 
 type VitestReporterEntry = string | [string, unknown] | {
   onTestRunEnd?: () => Promise<void>;
@@ -36,22 +36,6 @@ export interface CognitiveTypescriptVitestOptions {
   threshold?: number;
   stdout?: Writer;
   stderr?: Writer;
-}
-
-interface ResolvedReporterOptions {
-  projectRoot: string;
-  paths: string[];
-  changedOnly: boolean;
-  format: ReportFormat;
-  agent: boolean;
-  failuresOnly: boolean | undefined;
-  omitRedundancy: boolean | undefined;
-  output: string | undefined;
-  junit: boolean;
-  junitReport: string;
-  threshold: number;
-  stdout: Writer;
-  stderr: Writer;
 }
 
 const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
@@ -145,23 +129,8 @@ export function withCognitiveTypescriptVitest(
   };
 }
 
-function resolveReporterOptions(options: CognitiveTypescriptVitestOptions): ResolvedReporterOptions {
-  const agent = options.agent ?? false;
-  return {
-    projectRoot: options.projectRoot ?? process.cwd(),
-    paths: options.paths ?? [],
-    changedOnly: options.changedOnly ?? false,
-    format: options.format ?? (agent ? "toon" : "none"),
-    agent,
-    failuresOnly: options.failuresOnly,
-    omitRedundancy: options.omitRedundancy,
-    output: options.output,
-    junit: options.junit ?? true,
-    junitReport: options.junitReport ?? DEFAULT_JUNIT_REPORT,
-    threshold: options.threshold ?? COGNITIVE_COMPLEXITY_THRESHOLD,
-    stdout: options.stdout ?? process.stdout,
-    stderr: options.stderr ?? process.stderr
-  };
+function resolveReporterOptions(options: CognitiveTypescriptVitestOptions): ResolvedReporterReportOptions {
+  return resolveReporterReportOptions(options, DEFAULT_JUNIT_REPORT);
 }
 
 function asArray<T>(value: T | T[] | undefined): T[] {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,7 +1,6 @@
-import path from "node:path";
-
 import {
   analyzeProject,
+  DEFAULT_JUNIT_REPORT,
   deleteOwnedReportFile,
   NO_ANALYZABLE_FUNCTIONS_MESSAGE,
   NO_FILES_MESSAGE,
@@ -9,7 +8,7 @@ import {
   resolveReporterReportOptions,
   validateReportPathTargets
 } from "@barney-media/cognitive-typescript-core";
-import type { ReportFormat, ResolvedReporterReportOptions, Writer } from "@barney-media/cognitive-typescript-core";
+import type { ReporterReportOptions, ResolvedReporterReportOptions } from "@barney-media/cognitive-typescript-core";
 
 type VitestReporterEntry = string | [string, unknown] | {
   onTestRunEnd?: () => Promise<void>;
@@ -22,23 +21,7 @@ type VitestConfig = Record<string, unknown> & {
   };
 };
 
-export interface CognitiveTypescriptVitestOptions {
-  projectRoot?: string;
-  changedOnly?: boolean;
-  paths?: string[];
-  format?: ReportFormat;
-  agent?: boolean;
-  failuresOnly?: boolean;
-  omitRedundancy?: boolean;
-  output?: string;
-  junit?: boolean;
-  junitReport?: string;
-  threshold?: number;
-  stdout?: Writer;
-  stderr?: Writer;
-}
-
-const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
+export interface CognitiveTypescriptVitestOptions extends ReporterReportOptions {}
 
 export class CognitiveTypescriptVitestReporter {
   private finalizePromise: Promise<void> | null = null;

--- a/packages/vitest/test/config.test.ts
+++ b/packages/vitest/test/config.test.ts
@@ -29,4 +29,27 @@ describe("withCognitiveTypescriptVitest", () => {
       expect.any(CognitiveTypescriptVitestReporter)
     ]);
   });
+
+  it("forwards options without mutating coverage settings", () => {
+    const options = {
+      format: "json" as const,
+      junit: false,
+      threshold: 9
+    };
+    const config = withCognitiveTypescriptVitest(
+      {
+        test: {
+          coverage: {
+            provider: "v8"
+          }
+        }
+      },
+      options
+    );
+
+    expect(config.test?.coverage).toEqual({ provider: "v8" });
+    const reporters = config.test?.reporters as unknown[];
+    const reporter = reporters[1] as CognitiveTypescriptVitestReporter & { options: unknown };
+    expect(reporter.options).toEqual(options);
+  });
 });

--- a/packages/vitest/test/integration.test.ts
+++ b/packages/vitest/test/integration.test.ts
@@ -41,7 +41,7 @@ module.exports = withCognitiveTypescriptVitest(
       projectRoot
     );
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(2);
     expect(`${result.stdout}\n${result.stderr}`).toContain("Cognitive Complexity threshold exceeded");
   });
 });

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -1,9 +1,14 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { StringWriter, createTempDir, disposeTempDir, writeProjectFiles } from "../../core/test/testUtils";
 import { CognitiveTypescriptVitestReporter } from "../src/index";
 
 const tempDirs: string[] = [];
+const DEFAULT_JUNIT_REPORT = path.join("reports", "cognitive-typescript", "TEST-cognitive-typescript.xml");
 let originalExitCode: number | undefined;
 
 beforeEach(() => {
@@ -37,12 +42,9 @@ describe("CognitiveTypescriptVitestReporter", () => {
     expect(stderr.toString()).toBe("");
   });
 
-  it("prints the report and sets a failure exit code when the threshold is exceeded", async () => {
-    const projectRoot = await createTempDir("cognitive-vitest-reporter-");
-    tempDirs.push(projectRoot);
-    await writeProjectFiles(projectRoot, {
-      "package.json": '{"name":"fixture","private":true}',
-      "src/sample.ts": `${buildDeepNestedIfFunction("tooComplex", 7)}`
+  it("writes only the default JUnit sidecar with default report controls", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
     });
 
     const stdout = new StringWriter();
@@ -56,11 +58,175 @@ describe("CognitiveTypescriptVitestReporter", () => {
 
     await reporter.onTestRunEnd();
 
-    expect(stdout.toString()).toContain("tooComplex");
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe("");
+    const junit = await readText(path.join(projectRoot, DEFAULT_JUNIT_REPORT));
+    expect(junit).toContain("<testsuites");
+    expect(junit).toContain('classname="src/sample.ts"');
+    expect(junit).toContain('<property name="status" value="passed"/>');
+  });
+
+  it("writes configured primary and JUnit reports through the shared pipeline", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      format: "json",
+      agent: true,
+      failuresOnly: false,
+      omitRedundancy: true,
+      output: "reports/primary.json",
+      junit: true,
+      junitReport: "reports/custom-junit.xml",
+      threshold: 9,
+      stdout,
+      stderr
+    });
+
+    await reporter.onTestRunEnd();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe("");
+    const primary = JSON.parse(await readText(path.join(projectRoot, "reports", "primary.json"))) as {
+      threshold: number;
+      methods: Array<Record<string, unknown>>;
+    };
+    expect(primary.threshold).toBe(9);
+    expect(primary.methods).toEqual([
+      expect.objectContaining({
+        method: "safe"
+      })
+    ]);
+    expect(primary.methods[0]).not.toHaveProperty("status");
+    expect(existsSync(path.join(projectRoot, DEFAULT_JUNIT_REPORT))).toBe(false);
+    const junit = await readText(path.join(projectRoot, "reports", "custom-junit.xml"));
+    expect(junit).toContain('classname="src/sample.ts"');
+    expect(junit).toContain('<property name="status" value="passed"/>');
+  });
+
+  it("lets explicit agent overrides keep full output", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": `${buildSimpleFunction("safe")}\n\n${buildDeepNestedIfFunction("tooComplex", 7)}`
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      format: "json",
+      agent: true,
+      failuresOnly: false,
+      omitRedundancy: false,
+      stdout,
+      stderr
+    });
+
+    await reporter.onTestRunEnd();
+
+    const primary = JSON.parse(stdout.toString()) as {
+      methods: Array<Record<string, unknown>>;
+    };
+    expect(primary.methods).toHaveLength(2);
+    expect(primary.methods).toEqual(expect.arrayContaining([
+      expect.objectContaining({ method: "safe", status: "passed" }),
+      expect.objectContaining({ method: "tooComplex", status: "failed" })
+    ]));
     expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded");
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("suppresses and cleans the JUnit sidecar when junit is disabled", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
+    });
+    await mkdir(path.dirname(path.join(projectRoot, DEFAULT_JUNIT_REPORT)), { recursive: true });
+    await writeFile(path.join(projectRoot, DEFAULT_JUNIT_REPORT), "stale");
+
+    const reporter = new CognitiveTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      format: "json",
+      output: "reports/primary.json",
+      junit: false,
+      stdout: new StringWriter(),
+      stderr: new StringWriter()
+    });
+
+    await reporter.onTestRunEnd();
+
+    expect(existsSync(path.join(projectRoot, DEFAULT_JUNIT_REPORT))).toBe(false);
+    expect(await readText(path.join(projectRoot, "reports", "primary.json"))).toContain('"status": "passed"');
+  });
+
+  it("reports invalid report paths as configuration errors", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      output: "../outside.json",
+      stdout,
+      stderr
+    });
+
+    await reporter.onTestRunEnd();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toContain("--output must stay inside the project root");
     expect(process.exitCode).toBe(1);
   });
+
+  it("sets exit code 2 when the threshold is exceeded", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildDeepNestedIfFunction("tooComplex", 7)
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      format: "text",
+      stdout,
+      stderr
+    });
+
+    await reporter.onTestRunEnd();
+
+    expect(stdout.toString()).toContain("tooComplex");
+    expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded");
+    expect(process.exitCode).toBe(2);
+  });
 });
+
+async function createProject(files: Record<string, string>): Promise<string> {
+  const projectRoot = await createTempDir("cognitive-vitest-reporter-");
+  tempDirs.push(projectRoot);
+  await writeProjectFiles(projectRoot, {
+    "package.json": '{"name":"fixture","private":true}',
+    ...files
+  });
+  return projectRoot;
+}
+
+function buildSimpleFunction(name: string): string {
+  return `export function ${name}(value: boolean): number {
+  if (value) {
+    return 1;
+  }
+  return 0;
+}`;
+}
 
 function buildDeepNestedIfFunction(name: string, depth: number): string {
   const parameters = Array.from({ length: depth }, (_value, index) => `flag${index + 1}: boolean`).join(", ");
@@ -78,4 +244,8 @@ function buildDeepNestedIfFunction(name: string, depth: number): string {
   lines.push("  return 0;");
   lines.push("}");
   return lines.join("\n");
+}
+
+async function readText(filePath: string): Promise<string> {
+  return readFile(filePath, "utf8");
 }

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { NO_ANALYZABLE_FUNCTIONS_MESSAGE } from "@barney-media/cognitive-typescript-core";
 import { StringWriter, createTempDir, disposeTempDir, writeProjectFiles } from "../../core/test/testUtils";
 import { CognitiveTypescriptVitestReporter } from "../src/index";
 
@@ -39,6 +40,26 @@ describe("CognitiveTypescriptVitestReporter", () => {
     await reporter.onTestRunEnd();
 
     expect(stdout.toString()).toContain("No TypeScript files to analyze.");
+    expect(stderr.toString()).toBe("");
+  });
+
+  it("prints the no-analyzable-functions message when selected files contain declarations only", async () => {
+    const projectRoot = await createProject({
+      "src/types.ts": "export interface Sample { value: string; }"
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CognitiveTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      stdout,
+      stderr
+    });
+
+    await reporter.onTestRunEnd();
+
+    expect(stdout.toString()).toContain(NO_ANALYZABLE_FUNCTIONS_MESSAGE);
     expect(stderr.toString()).toBe("");
   });
 
@@ -146,7 +167,10 @@ describe("CognitiveTypescriptVitestReporter", () => {
       "src/sample.ts": buildSimpleFunction("safe")
     });
     await mkdir(path.dirname(path.join(projectRoot, DEFAULT_JUNIT_REPORT)), { recursive: true });
-    await writeFile(path.join(projectRoot, DEFAULT_JUNIT_REPORT), "stale");
+    await writeFile(
+      path.join(projectRoot, DEFAULT_JUNIT_REPORT),
+      '<?xml version="1.0" encoding="UTF-8"?><testsuites name="cognitive-typescript"></testsuites>'
+    );
 
     const reporter = new CognitiveTypescriptVitestReporter({
       projectRoot,
@@ -161,6 +185,30 @@ describe("CognitiveTypescriptVitestReporter", () => {
     await reporter.onTestRunEnd();
 
     expect(existsSync(path.join(projectRoot, DEFAULT_JUNIT_REPORT))).toBe(false);
+    expect(await readText(path.join(projectRoot, "reports", "primary.json"))).toContain('"status": "passed"');
+  });
+
+  it("does not validate or delete unrelated junit paths when junit is disabled", async () => {
+    const projectRoot = await createProject({
+      "src/sample.ts": buildSimpleFunction("safe")
+    });
+    const externalReport = path.join(projectRoot, "..", "outside-junit.xml");
+    await writeFile(externalReport, "unrelated");
+
+    const reporter = new CognitiveTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      format: "json",
+      output: "reports/primary.json",
+      junit: false,
+      junitReport: "../outside-junit.xml",
+      stdout: new StringWriter(),
+      stderr: new StringWriter()
+    });
+
+    await reporter.onTestRunEnd();
+
+    expect(await readText(externalReport)).toBe("unrelated");
     expect(await readText(path.join(projectRoot, "reports", "primary.json"))).toContain('"status": "passed"');
   });
 


### PR DESCRIPTION
## Summary
- route Jest and Vitest reporting through the shared core publish pipeline and expose aligned report-control options
- keep reporter behavior static-analysis-only, including threshold exit code 2 and no coverage mutation
- add focused reporter and config coverage for defaults, overrides, disabled JUnit, output validation, and exit-code handling

## Testing
- npm run build
- npm test
- npm run cognitive-typescript-check

Closes #18