### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the most recent published release only. Please upgrade to the latest release before reporting an issue that may already be fixed.
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities privately through GitHub Security Advisories:
+
+https://github.com/fabian-barney/cognitive-typescript/security/advisories/new
+
+Do not open a public issue for suspected vulnerabilities.
+
+Reports are handled on a best-effort basis. You can generally expect an acknowledgement and preliminary severity assessment within 14 days when the report includes enough information to reproduce or reason about the issue. This project does not currently run a paid bug bounty program.


### PR DESCRIPTION
## Summary
- add a repository-level `SECURITY.md` aligned with the sibling projects
- document supported-version expectations, private reporting via GitHub Security Advisories, and the no-public-issue rule

## Testing
- documentation-only change

Closes #24