### PR TITLE
Harden TypeScript file selection and changed-only execution

### DIFF
--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -1,14 +1,19 @@
-import { readdir, stat } from "node:fs/promises";
+import { lstat, readdir } from "node:fs/promises";
 import path from "node:path";
 
 import { DEFAULT_EXCLUDED_SOURCE_ROOT_DISCOVERY_DIRECTORIES, IGNORED_DIRECTORIES } from "./constants";
 import { runCommand, toRelativePath } from "./utils";
 
-const ANALYZABLE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
+const SOURCE_FILE_SUFFIXES = [".ts", ".tsx", ".mts", ".cts"];
+const DECLARATION_FILE_SUFFIXES = [".d.ts", ".d.mts", ".d.cts"];
+const GIT_STATUS_TIMEOUT_MS = 30_000;
+const MAX_CAPTURED_GIT_OUTPUT_BYTES = 64 * 1024;
 
 interface FileSelectionOptions {
   pruneDefaultExcludedDirectories?: boolean;
 }
+
+type CommandRunner = typeof runCommand;
 
 export async function findAllTypeScriptFilesUnderSourceRoots(
   projectRoot: string,
@@ -31,7 +36,10 @@ export async function expandExplicitPaths(
   const files = new Set<string>();
   for (const value of values) {
     const resolvedPath = path.resolve(projectRoot, value);
-    const fileStats = await stat(resolvedPath);
+    const fileStats = await lstat(resolvedPath);
+    if (fileStats.isSymbolicLink()) {
+      continue;
+    }
     if (fileStats.isDirectory()) {
       await expandDirectoryPath(resolvedPath, files, options);
       continue;
@@ -43,14 +51,17 @@ export async function expandExplicitPaths(
   return Array.from(files).sort();
 }
 
-export async function changedTypeScriptFilesUnderSourceRoots(projectRoot: string): Promise<string[]> {
-  const entries = await readChangedFileStatusEntries(projectRoot);
+export async function changedTypeScriptFilesUnderSourceRoots(
+  projectRoot: string,
+  commandRunner: CommandRunner = runCommand
+): Promise<string[]> {
+  const entries = await readChangedFileStatusEntries(projectRoot, commandRunner);
   return Array.from(collectChangedFilesFromStatus(projectRoot, entries)).sort();
 }
 
 export function isAnalyzableFile(filePath: string): boolean {
   const normalized = toRelativePath(path.parse(filePath).root, filePath).toLowerCase();
-  return hasAnySuffix(normalized, ANALYZABLE_EXTENSIONS);
+  return hasDeclarationFileSuffix(normalized) || hasAnySuffix(normalized, SOURCE_FILE_SUFFIXES);
 }
 
 interface GitStatusEntry {
@@ -106,24 +117,58 @@ function isRenameOrCopyStatus(status: string): boolean {
   return status.includes("R") || status.includes("C");
 }
 
-function hasAnySuffix(value: string, suffixes: string[]): boolean {
+function hasAnySuffix(value: string, suffixes: readonly string[]): boolean {
   return suffixes.some((suffix) => value.endsWith(suffix));
 }
 
-async function readChangedFileStatusEntries(projectRoot: string): Promise<string[]> {
-  const result = await runCommand("git", ["status", "--porcelain", "-z"], projectRoot);
-  if (result.exitCode === 0) {
-    return result.stdout.split("\0");
+function hasDeclarationFileSuffix(normalizedPath: string): boolean {
+  return hasAnySuffix(normalizedPath, DECLARATION_FILE_SUFFIXES);
+}
+
+async function readChangedFileStatusEntries(
+  projectRoot: string,
+  commandRunner: CommandRunner
+): Promise<string[]> {
+  const result = await commandRunner(
+    "git",
+    ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+    projectRoot,
+    {
+      timeoutMs: GIT_STATUS_TIMEOUT_MS,
+      maxOutputBytes: MAX_CAPTURED_GIT_OUTPUT_BYTES
+    }
+  );
+  if (result.timedOut) {
+    throw new Error(`git status --porcelain timed out after ${GIT_STATUS_TIMEOUT_MS}ms${formatCommandContext(result)}`);
   }
-  throw new Error(readChangedFileStatusError(result.stderr));
+  if (result.exitCode !== 0) {
+    throw new Error(readChangedFileStatusError(result));
+  }
+  if (!result.stdoutComplete) {
+    throw new Error(`could not fully capture git status --porcelain output; refusing incomplete changed-file detection${formatCommandContext(result)}`);
+  }
+  return result.stdout.split("\0");
+}
+
+function formatCommandContext(result: Awaited<ReturnType<CommandRunner>>): string {
+  const details: string[] = [];
+  const stdout = result.stdout.trim();
+  const stderr = result.stderr.trim();
+  if (stdout.length > 0) {
+    details.push(`stdout: ${stdout}`);
+  }
+  if (stderr.length > 0) {
+    details.push(`stderr: ${stderr}`);
+  }
+  return details.length === 0 ? "" : ` (${details.join("; ")})`;
 }
 
 function isIncludedTrackedStatus(status: string): boolean {
   return !status.includes("D") && /[AMRCU]/.test(status);
 }
 
-function readChangedFileStatusError(stderr: string): string {
-  const message = stderr.trim();
+function readChangedFileStatusError(result: Awaited<ReturnType<CommandRunner>>): string {
+  const message = result.stderr.trim() || result.stdout.trim();
   return message || "git status --porcelain failed";
 }
 
@@ -148,10 +193,10 @@ async function walkForSourceRoots(
 }
 
 function classifySourceRootEntry(
-  entry: { isDirectory(): boolean; name: string },
+  entry: { isDirectory(): boolean; isSymbolicLink(): boolean; name: string },
   options: FileSelectionOptions
 ): "skip" | "source-root" | "descend" {
-  if (!entry.isDirectory()) {
+  if (!entry.isDirectory() || entry.isSymbolicLink()) {
     return "skip";
   }
   const lowerName = entry.name.toLowerCase();
@@ -167,6 +212,9 @@ async function walkSourceTree(
 ): Promise<void> {
   const entries = await readdir(currentDir, { withFileTypes: true });
   for (const entry of entries) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
     const absolutePath = path.join(currentDir, entry.name);
     if (entry.isDirectory()) {
       await walkDirectoryEntry(entry.name, absolutePath, onFile);
@@ -183,7 +231,7 @@ async function walkDirectoryEntry(
   absolutePath: string,
   onFile: (filePath: string) => Promise<void>
 ): Promise<void> {
-  if (IGNORED_DIRECTORIES.has(entryName)) {
+  if (IGNORED_DIRECTORIES.has(entryName.toLowerCase())) {
     return;
   }
   await walkSourceTree(absolutePath, onFile);

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -159,8 +159,8 @@ async function readChangedFileStatusEntries(
 
 function formatCommandContext(result: Awaited<ReturnType<CommandRunner>>): string {
   const details: string[] = [];
-  const stdout = sanitizeCommandOutput(result.stdout).trim();
-  const stderr = sanitizeCommandOutput(result.stderr).trim();
+  const stdout = sanitizeCommandOutput(result.stdout).trimEnd();
+  const stderr = sanitizeCommandOutput(result.stderr).trimEnd();
   if (stdout.length > 0) {
     details.push(`stdout: ${stdout}`);
   }

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -96,6 +96,10 @@ function collectChangedFilesFromStatus(projectRoot: string, entries: string[]): 
     if (!entry) {
       continue;
     }
+    const renameOrCopyDestination = isRenameOrCopyStatus(entry.status) ? entries[index + 1] : undefined;
+    if (renameOrCopyDestination) {
+      entry.pathValue = renameOrCopyDestination;
+    }
     collectChangedFile(projectRoot, entry, files);
     if (isRenameOrCopyStatus(entry.status)) {
       index += 1;

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -8,6 +8,7 @@ const SOURCE_FILE_SUFFIXES = [".ts", ".tsx", ".mts", ".cts"];
 const DECLARATION_FILE_SUFFIXES = [".d.ts", ".d.mts", ".d.cts"];
 const GIT_STATUS_TIMEOUT_MS = 30_000;
 const MAX_CAPTURED_GIT_OUTPUT_BYTES = 64 * 1024;
+const GIT_STATUS_COMMAND_DESCRIPTION = "git status --porcelain=v1 -z --untracked-files=all";
 
 interface FileSelectionOptions {
   pruneDefaultExcludedDirectories?: boolean;
@@ -143,21 +144,23 @@ async function readChangedFileStatusEntries(
     }
   );
   if (result.timedOut) {
-    throw new Error(`git status --porcelain timed out after ${GIT_STATUS_TIMEOUT_MS}ms${formatCommandContext(result)}`);
+    throw new Error(`${GIT_STATUS_COMMAND_DESCRIPTION} timed out after ${GIT_STATUS_TIMEOUT_MS}ms${formatCommandContext(result)}`);
   }
   if (result.exitCode !== 0) {
     throw new Error(readChangedFileStatusError(result));
   }
   if (!result.stdoutComplete) {
-    throw new Error(`could not fully capture git status --porcelain output; refusing incomplete changed-file detection${formatCommandContext(result)}`);
+    throw new Error(
+      `could not fully capture ${GIT_STATUS_COMMAND_DESCRIPTION} output; refusing incomplete changed-file detection${formatCommandContext(result)}`
+    );
   }
   return result.stdout.split("\0");
 }
 
 function formatCommandContext(result: Awaited<ReturnType<CommandRunner>>): string {
   const details: string[] = [];
-  const stdout = result.stdout.trim();
-  const stderr = result.stderr.trim();
+  const stdout = sanitizeCommandOutput(result.stdout).trim();
+  const stderr = sanitizeCommandOutput(result.stderr).trim();
   if (stdout.length > 0) {
     details.push(`stdout: ${stdout}`);
   }
@@ -167,13 +170,17 @@ function formatCommandContext(result: Awaited<ReturnType<CommandRunner>>): strin
   return details.length === 0 ? "" : ` (${details.join("; ")})`;
 }
 
+function sanitizeCommandOutput(value: string): string {
+  return value.replaceAll("\0", "\\0");
+}
+
 function isIncludedTrackedStatus(status: string): boolean {
   return !status.includes("D") && /[AMRCU]/.test(status);
 }
 
 function readChangedFileStatusError(result: Awaited<ReturnType<CommandRunner>>): string {
   const message = result.stderr.trim() || result.stdout.trim();
-  return message || "git status --porcelain failed";
+  return message || `${GIT_STATUS_COMMAND_DESCRIPTION} failed`;
 }
 
 async function walkForSourceRoots(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -18,6 +18,8 @@ interface RunCommandResult {
   timedOut: boolean;
 }
 
+const FORCE_KILL_TIMEOUT_MS = 1_000;
+
 export function writeLine(writer: Writer | undefined, message: string): void {
   writer?.write(`${message}\n`);
 }
@@ -54,11 +56,28 @@ export async function runCommand(
     const stdout = createBoundedOutput(options.maxOutputBytes);
     const stderr = createBoundedOutput(options.maxOutputBytes);
     let timedOut = false;
-    const timeout = options.timeoutMs === undefined
+    let timeout: NodeJS.Timeout | undefined;
+    let forceKillTimeout: NodeJS.Timeout | undefined;
+
+    const clearTimers = () => {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+      if (forceKillTimeout !== undefined) {
+        clearTimeout(forceKillTimeout);
+      }
+    };
+
+    timeout = options.timeoutMs === undefined
       ? undefined
       : setTimeout(() => {
         timedOut = true;
+        stdout.markIncomplete();
+        stderr.markIncomplete();
         child.kill();
+        forceKillTimeout = setTimeout(() => {
+          child.kill("SIGKILL");
+        }, FORCE_KILL_TIMEOUT_MS);
       }, options.timeoutMs);
 
     child.stdout.on("data", (chunk) => {
@@ -73,11 +92,14 @@ export async function runCommand(
     child.stderr.on("error", () => {
       stderr.markIncomplete();
     });
-    child.on("error", reject);
+    child.on("error", (error) => {
+      clearTimers();
+      stdout.markIncomplete();
+      stderr.markIncomplete();
+      reject(error);
+    });
     child.on("close", (exitCode) => {
-      if (timeout !== undefined) {
-        clearTimeout(timeout);
-      }
+      clearTimers();
       resolve({
         exitCode: exitCode ?? 1,
         stdout: stdout.text(),

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -3,6 +3,21 @@ import { spawn } from "node:child_process";
 
 import type { Writer } from "./types";
 
+interface RunCommandOptions {
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+interface RunCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  stdoutComplete: boolean;
+  stderrComplete: boolean;
+  timedOut: boolean;
+}
+
 export function writeLine(writer: Writer | undefined, message: string): void {
   writer?.write(`${message}\n`);
 }
@@ -27,28 +42,49 @@ export function toRelativePath(projectRoot: string, filePath: string): string {
 export async function runCommand(
   command: string,
   args: string[],
-  cwd: string
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  cwd: string,
+  options: RunCommandOptions = {}
+): Promise<RunCommandResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
+      env: options.env,
       stdio: ["ignore", "pipe", "pipe"]
     });
-    let stdout = "";
-    let stderr = "";
+    const stdout = createBoundedOutput(options.maxOutputBytes);
+    const stderr = createBoundedOutput(options.maxOutputBytes);
+    let timedOut = false;
+    const timeout = options.timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => {
+        timedOut = true;
+        child.kill();
+      }, options.timeoutMs);
 
     child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
+      stdout.write(chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
+      stderr.write(chunk);
+    });
+    child.stdout.on("error", () => {
+      stdout.markIncomplete();
+    });
+    child.stderr.on("error", () => {
+      stderr.markIncomplete();
     });
     child.on("error", reject);
     child.on("close", (exitCode) => {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
       resolve({
         exitCode: exitCode ?? 1,
-        stdout,
-        stderr
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+        stdoutComplete: stdout.isComplete(),
+        stderrComplete: stderr.isComplete(),
+        timedOut
       });
     });
   });
@@ -60,4 +96,56 @@ export function formatNumber(value: number): string {
 
 export function resolveScriptKind(filePath: string): "ts" | "tsx" {
   return filePath.toLowerCase().endsWith(".tsx") ? "tsx" : "ts";
+}
+
+function createBoundedOutput(maxOutputBytes: number | undefined) {
+  let text = "";
+  let capturedBytes = 0;
+  let complete = true;
+
+  return {
+    write(chunk: Buffer | string) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      const bytesToCapture = captureLength(buffer.length, maxOutputBytes, capturedBytes);
+      if (bytesToCapture === 0) {
+        if (buffer.length > 0) {
+          complete = false;
+        }
+        return;
+      }
+      capturedBytes += bytesToCapture;
+      text += buffer.subarray(0, bytesToCapture).toString();
+      if (bytesToCapture < buffer.length) {
+        complete = false;
+      }
+    },
+    markIncomplete() {
+      complete = false;
+    },
+    isComplete() {
+      return complete;
+    },
+    text() {
+      if (complete) {
+        return text;
+      }
+      const trimmed = text.trim();
+      return trimmed.length === 0 ? "[output truncated]" : `${trimmed} [output truncated]`;
+    }
+  };
+}
+
+function captureLength(
+  bufferLength: number,
+  maxOutputBytes: number | undefined,
+  capturedBytes: number
+): number {
+  if (maxOutputBytes === undefined) {
+    return bufferLength;
+  }
+  const remaining = maxOutputBytes - capturedBytes;
+  if (remaining <= 0) {
+    return 0;
+  }
+  return Math.min(bufferLength, remaining);
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -151,7 +151,7 @@ function createBoundedOutput(maxOutputBytes: number | undefined) {
       if (complete) {
         return text;
       }
-      const trimmed = text.trim();
+      const trimmed = text.trimEnd();
       return trimmed.length === 0 ? "[output truncated]" : `${trimmed} [output truncated]`;
     }
   };

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -1,8 +1,10 @@
+import { symlink } from "node:fs/promises";
 import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  isAnalyzableFile,
   changedTypeScriptFilesUnderSourceRoots,
   expandExplicitPaths,
   findAllTypeScriptFilesUnderSourceRoots
@@ -63,6 +65,7 @@ describe("file selection", () => {
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
       "src/root.ts": "export const root = 1;\n",
+      "dist/src/root-generated.ts": "export const rootGenerated = 1;\n",
       "packages/web/src/page.ts": "export const page = 1;\n",
       "packages/web/dist/src/generated.ts": "export const generated = 1;\n",
       "packages/web/coverage/src/covered.ts": "export const covered = 1;\n",
@@ -76,6 +79,17 @@ describe("file selection", () => {
       "packages/web/src/page.ts",
       "src/root.ts"
     ]);
+  });
+
+  it("keeps declaration and implementation suffix handling explicit", () => {
+    expect(isAnalyzableFile("C:/repo/src/file.ts")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/file.tsx")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/file.mts")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/file.cts")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/file.d.ts")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/file.d.mts")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/file.d.cts")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/file.js")).toBe(false);
   });
 
   it("does not prune build-output src roots when discovery pruning is disabled", async () => {
@@ -113,5 +127,72 @@ describe("file selection", () => {
     expect(changed.map((file) => path.relative(projectRoot, file).replace(/\\/g, "/"))).toEqual([
       "src/changed.ts"
     ]);
+  });
+
+  it("does not follow symlinked directories during discovery or explicit expansion", async () => {
+    const projectRoot = await createTempDir("cognitive-files-");
+    const linkedRoot = await createTempDir("cognitive-linked-");
+    tempDirs.push(projectRoot, linkedRoot);
+    await writeProjectFiles(projectRoot, {
+      "src/root.ts": "export const root = 1;\n"
+    });
+    await writeProjectFiles(linkedRoot, {
+      "src/linked.ts": "export const linked = 1;\n"
+    });
+    await symlink(
+      linkedRoot,
+      path.join(projectRoot, "linked"),
+      process.platform === "win32" ? "junction" : "dir"
+    );
+
+    const discovered = await findAllTypeScriptFilesUnderSourceRoots(projectRoot);
+    expect(discovered.map((file) => path.relative(projectRoot, file).replace(/\\/g, "/"))).toEqual([
+      "src/root.ts"
+    ]);
+
+    const expanded = await expandExplicitPaths(projectRoot, ["linked"]);
+    expect(expanded).toEqual([]);
+  });
+
+  it("reports git status timeouts with captured context", async () => {
+    await expect(changedTypeScriptFilesUnderSourceRoots(
+      "C:/repo",
+      async () => ({
+        exitCode: 1,
+        stdout: "partial stdout",
+        stderr: "partial stderr",
+        stdoutComplete: true,
+        stderrComplete: true,
+        timedOut: true
+      })
+    )).rejects.toThrow("git status --porcelain timed out after 30000ms (stdout: partial stdout; stderr: partial stderr)");
+  });
+
+  it("rejects incomplete git status output on success", async () => {
+    await expect(changedTypeScriptFilesUnderSourceRoots(
+      "C:/repo",
+      async () => ({
+        exitCode: 0,
+        stdout: "?? src/generated.ts [output truncated]",
+        stderr: "",
+        stdoutComplete: false,
+        stderrComplete: true,
+        timedOut: false
+      })
+    )).rejects.toThrow("could not fully capture git status --porcelain output; refusing incomplete changed-file detection");
+  });
+
+  it("surfaces git status failures from stderr or stdout", async () => {
+    await expect(changedTypeScriptFilesUnderSourceRoots(
+      "C:/repo",
+      async () => ({
+        exitCode: 1,
+        stdout: "stdout fallback",
+        stderr: "",
+        stdoutComplete: true,
+        stderrComplete: true,
+        timedOut: false
+      })
+    )).rejects.toThrow("stdout fallback");
   });
 });

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -130,8 +130,11 @@ describe("file selection", () => {
   });
 
   it("prefers the destination path for renamed or copied src files", async () => {
+    const projectRoot = await createTempDir("cognitive-files-");
+    tempDirs.push(projectRoot);
+
     const changed = await changedTypeScriptFilesUnderSourceRoots(
-      "C:/repo",
+      projectRoot,
       async () => ({
         exitCode: 0,
         stdout: "R  src/old-name.ts\0src/new-name.ts\0C  src/original.ts\0src/copied.ts\0",
@@ -142,7 +145,7 @@ describe("file selection", () => {
       })
     );
 
-    expect(changed.map((file) => path.relative("C:/repo", file).replace(/\\/g, "/"))).toEqual([
+    expect(changed.map((file) => path.relative(projectRoot, file).replace(/\\/g, "/"))).toEqual([
       "src/copied.ts",
       "src/new-name.ts"
     ]);

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -184,7 +184,9 @@ describe("file selection", () => {
         stderrComplete: true,
         timedOut: true
       })
-    )).rejects.toThrow("git status --porcelain timed out after 30000ms (stdout: partial stdout; stderr: partial stderr)");
+    )).rejects.toThrow(
+      "git status --porcelain=v1 -z --untracked-files=all timed out after 30000ms (stdout: partial stdout; stderr: partial stderr)"
+    );
   });
 
   it("rejects incomplete git status output on success", async () => {
@@ -198,7 +200,23 @@ describe("file selection", () => {
         stderrComplete: true,
         timedOut: false
       })
-    )).rejects.toThrow("could not fully capture git status --porcelain output; refusing incomplete changed-file detection");
+    )).rejects.toThrow(
+      "could not fully capture git status --porcelain=v1 -z --untracked-files=all output; refusing incomplete changed-file detection"
+    );
+  });
+
+  it("sanitizes NUL bytes in git status error context", async () => {
+    await expect(changedTypeScriptFilesUnderSourceRoots(
+      "C:/repo",
+      async () => ({
+        exitCode: 0,
+        stdout: "?? src/added.ts\0M  src/changed.ts\0",
+        stderr: "",
+        stdoutComplete: false,
+        stderrComplete: true,
+        timedOut: false
+      })
+    )).rejects.toThrow("stdout: ?? src/added.ts\\0M  src/changed.ts\\0");
   });
 
   it("surfaces git status failures from stderr or stdout", async () => {

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -129,6 +129,25 @@ describe("file selection", () => {
     ]);
   });
 
+  it("prefers the destination path for renamed or copied src files", async () => {
+    const changed = await changedTypeScriptFilesUnderSourceRoots(
+      "C:/repo",
+      async () => ({
+        exitCode: 0,
+        stdout: "R  src/old-name.ts\0src/new-name.ts\0C  src/original.ts\0src/copied.ts\0",
+        stderr: "",
+        stdoutComplete: true,
+        stderrComplete: true,
+        timedOut: false
+      })
+    );
+
+    expect(changed.map((file) => path.relative("C:/repo", file).replace(/\\/g, "/"))).toEqual([
+      "src/copied.ts",
+      "src/new-name.ts"
+    ]);
+  });
+
   it("does not follow symlinked directories during discovery or explicit expansion", async () => {
     const projectRoot = await createTempDir("cognitive-files-");
     const linkedRoot = await createTempDir("cognitive-linked-");

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -8,7 +8,7 @@ describe("runCommand", () => {
       process.execPath,
       ["-e", "process.stdout.write('partial\\n'); setInterval(() => process.stdout.write('tick\\n'), 25);"],
       process.cwd(),
-      { timeoutMs: 300 }
+      { timeoutMs: 1_000 }
     );
 
     expect(result.timedOut).toBe(true);
@@ -28,6 +28,19 @@ describe("runCommand", () => {
     expect(result.stdoutComplete).toBe(false);
     expect(result.stdout).toContain("[output truncated]");
     expect(result.stdout.length).toBeLessThan(2_000);
+  });
+
+  it("preserves leading whitespace when incomplete output is truncated", async () => {
+    const result = await runCommand(
+      process.execPath,
+      ["-e", "process.stdout.write(' M src/changed.ts\\n'); process.stdout.write('x'.repeat(100_000));"],
+      process.cwd(),
+      { maxOutputBytes: 32 }
+    );
+
+    expect(result.stdoutComplete).toBe(false);
+    expect(result.stdout.startsWith(" M src/changed.ts")).toBe(true);
+    expect(result.stdout).toContain("[output truncated]");
   });
 
   it("captures complete output without a byte cap", async () => {

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { runCommand } from "../src/utils";
+
+describe("runCommand", () => {
+  it("times out long-running commands while preserving partial output", async () => {
+    const result = await runCommand(
+      process.execPath,
+      ["-e", "process.stdout.write('partial\\n'); setInterval(() => process.stdout.write('tick\\n'), 25);"],
+      process.cwd(),
+      { timeoutMs: 300 }
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.stdout).toContain("partial");
+  });
+
+  it("bounds captured output and marks incomplete streams", async () => {
+    const result = await runCommand(
+      process.execPath,
+      ["-e", "process.stdout.write('x'.repeat(100_000));"],
+      process.cwd(),
+      { maxOutputBytes: 1024 }
+    );
+
+    expect(result.stdoutComplete).toBe(false);
+    expect(result.stdout).toContain("[output truncated]");
+    expect(result.stdout.length).toBeLessThan(2_000);
+  });
+
+  it("captures complete output without a byte cap", async () => {
+    const result = await runCommand(
+      process.execPath,
+      ["-e", "process.stdout.write('complete output');"],
+      process.cwd()
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdoutComplete).toBe(true);
+    expect(result.stdout).toBe("complete output");
+  });
+
+});

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -13,6 +13,8 @@ describe("runCommand", () => {
 
     expect(result.timedOut).toBe(true);
     expect(result.stdout).toContain("partial");
+    expect(result.stdoutComplete).toBe(false);
+    expect(result.stderrComplete).toBe(false);
   });
 
   it("bounds captured output and marks incomplete streams", async () => {
@@ -38,6 +40,15 @@ describe("runCommand", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdoutComplete).toBe(true);
     expect(result.stdout).toBe("complete output");
+  });
+
+  it("rejects spawn failures without leaving timeout cleanup behind", async () => {
+    await expect(runCommand(
+      "__definitely_missing_command__",
+      [],
+      process.cwd(),
+      { timeoutMs: 300 }
+    )).rejects.toThrow();
   });
 
 });


### PR DESCRIPTION
Closes #21

## Summary
- harden source discovery and explicit path expansion to skip symlinked directories and prune default generated/build-output trees during source-root discovery when requested
- bound git status --porcelain -z execution with timeout and output caps, and fail closed on incomplete changed-file output
- add focused coverage for suffix handling, symlink traversal, timeout/error reporting, and bounded command output behavior