### PR TITLE
Strengthen TypeScript CI and release gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,15 +62,6 @@ jobs:
       - name: Verify workspace packages
         run: npm pack --workspaces
 
-      - name: Upload prepared CRAP gate build outputs
-        uses: actions/upload-artifact@v4
-        with:
-          name: prepared-crap-gate-ubuntu-22.12.0
-          path: |
-            packages/*/dist
-            packages/*/.tsbuildinfo
-          if-no-files-found: error
-
   ubuntu-build-node-24:
     name: Build and Test (Node 24.0.0, ubuntu-latest)
     runs-on: ubuntu-latest
@@ -96,15 +87,6 @@ jobs:
 
       - name: Verify workspace packages
         run: npm pack --workspaces
-
-      - name: Upload prepared CRAP gate build outputs
-        uses: actions/upload-artifact@v4
-        with:
-          name: prepared-crap-gate-ubuntu-24.0.0
-          path: |
-            packages/*/dist
-            packages/*/.tsbuildinfo
-          if-no-files-found: error
 
   cognitive-typescript-gate:
     name: cognitive-typescript Gate (Node ${{ matrix.node-version }})
@@ -150,14 +132,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download prepared CRAP gate build outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: prepared-crap-gate-ubuntu-22.12.0
-          path: .
-
       - name: Run crap-typescript gate
-        run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts
+        run: npm run crap-typescript-check
 
   crap-typescript-gate-node-24:
     name: crap-typescript Gate (Node 24.0.0)
@@ -180,14 +156,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download prepared CRAP gate build outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: prepared-crap-gate-ubuntu-24.0.0
-          path: .
-
       - name: Run crap-typescript gate
-        run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts
+        run: npm run crap-typescript-check
 
   crap-typescript-gate-required:
     name: crap-typescript Gate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build packages
-        run: npm run build
-
       - name: Run tests
         run: npm test
 
@@ -59,23 +56,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build packages
-        run: npm run build
-
       - name: Run tests
         run: npm test
 
       - name: Verify workspace packages
         run: npm pack --workspaces
 
-      - name: Save crap-typescript gate workspace
-        uses: actions/cache/save@v4
+      - name: Upload prepared CRAP gate build outputs
+        uses: actions/upload-artifact@v4
         with:
+          name: prepared-crap-gate-ubuntu-22.12.0
           path: |
-            node_modules
             packages/*/dist
             packages/*/.tsbuildinfo
-          key: cognitive-typescript-crap-gate-ubuntu-22.12.0-${{ github.sha }}
+          if-no-files-found: error
 
   ubuntu-build-node-24:
     name: Build and Test (Node 24.0.0, ubuntu-latest)
@@ -97,23 +91,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build packages
-        run: npm run build
-
       - name: Run tests
         run: npm test
 
       - name: Verify workspace packages
         run: npm pack --workspaces
 
-      - name: Save crap-typescript gate workspace
-        uses: actions/cache/save@v4
+      - name: Upload prepared CRAP gate build outputs
+        uses: actions/upload-artifact@v4
         with:
+          name: prepared-crap-gate-ubuntu-24.0.0
           path: |
-            node_modules
             packages/*/dist
             packages/*/.tsbuildinfo
-          key: cognitive-typescript-crap-gate-ubuntu-24.0.0-${{ github.sha }}
+          if-no-files-found: error
 
   cognitive-typescript-gate:
     name: cognitive-typescript Gate (Node ${{ matrix.node-version }})
@@ -151,16 +142,19 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22.12.0"
+          cache: npm
 
-      - name: Restore prepared workspace
-        uses: actions/cache/restore@v4
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download prepared CRAP gate build outputs
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            node_modules
-            packages/*/dist
-            packages/*/.tsbuildinfo
-          key: cognitive-typescript-crap-gate-ubuntu-22.12.0-${{ github.sha }}
-          fail-on-cache-miss: true
+          name: prepared-crap-gate-ubuntu-22.12.0
+          path: .
 
       - name: Run crap-typescript gate
         run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts
@@ -178,16 +172,19 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24.0.0"
+          cache: npm
 
-      - name: Restore prepared workspace
-        uses: actions/cache/restore@v4
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download prepared CRAP gate build outputs
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            node_modules
-            packages/*/dist
-            packages/*/.tsbuildinfo
-          key: cognitive-typescript-crap-gate-ubuntu-24.0.0-${{ github.sha }}
-          fail-on-cache-miss: true
+          name: prepared-crap-gate-ubuntu-24.0.0
+          path: .
 
       - name: Run crap-typescript gate
         run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,48 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build and Test
+  windows-build:
+    name: Build and Test (Node ${{ matrix.node-version }}, windows-latest)
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["22.12.0", "24.0.0"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+  ubuntu-build-node-22:
+    name: Build and Test (Node 22.12.0, ubuntu-latest)
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Node 24
+      - name: Set up Node 22.12.0
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22.12.0"
           cache: npm
 
       - name: Set up npm 11.14.1
@@ -38,18 +68,27 @@ jobs:
       - name: Verify workspace packages
         run: npm pack --workspaces
 
-  cognitive-typescript-gate:
-    name: cognitive-typescript Gate
+      - name: Save crap-typescript gate workspace
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            packages/*/dist
+            packages/*/.tsbuildinfo
+          key: cognitive-typescript-crap-gate-ubuntu-22.12.0-${{ github.sha }}
+
+  ubuntu-build-node-24:
+    name: Build and Test (Node 24.0.0, ubuntu-latest)
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Node 24
+      - name: Set up Node 24.0.0
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "24.0.0"
           cache: npm
 
       - name: Set up npm 11.14.1
@@ -57,29 +96,113 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify workspace packages
+        run: npm pack --workspaces
+
+      - name: Save crap-typescript gate workspace
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            packages/*/dist
+            packages/*/.tsbuildinfo
+          key: cognitive-typescript-crap-gate-ubuntu-24.0.0-${{ github.sha }}
+
+  cognitive-typescript-gate:
+    name: cognitive-typescript Gate (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["22.12.0", "24.0.0"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
 
       - name: Run cognitive-typescript gate
-        run: npm run cognitive-typescript-check
+        run: node ./scripts/run-cognitive-typescript-gate.mjs packages
 
-  crap-typescript-gate:
-    name: crap-typescript Gate
+  crap-typescript-gate-node-22:
+    name: crap-typescript Gate (Node 22.12.0)
     runs-on: ubuntu-latest
+    needs: [ubuntu-build-node-22]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Node 24
+      - name: Set up Node 22.12.0
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
-          cache: npm
+          node-version: "22.12.0"
 
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Restore prepared workspace
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            packages/*/dist
+            packages/*/.tsbuildinfo
+          key: cognitive-typescript-crap-gate-ubuntu-22.12.0-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Run crap-typescript gate
-        run: npm run crap-typescript-check
+        run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts
+
+  crap-typescript-gate-node-24:
+    name: crap-typescript Gate (Node 24.0.0)
+    runs-on: ubuntu-latest
+    needs: [ubuntu-build-node-24]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node 24.0.0
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.0.0"
+
+      - name: Restore prepared workspace
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            packages/*/dist
+            packages/*/.tsbuildinfo
+          key: cognitive-typescript-crap-gate-ubuntu-24.0.0-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Run crap-typescript gate
+        run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts
+
+  crap-typescript-gate-required:
+    name: crap-typescript Gate
+    runs-on: ubuntu-latest
+    needs: [crap-typescript-gate-node-22, crap-typescript-gate-node-24]
+    if: ${{ always() }}
+
+    steps:
+      - name: Require the matrix CRAP gate to pass
+        shell: bash
+        run: |
+          if [ "${{ needs.crap-typescript-gate-node-22.result }}" != "success" ] || [ "${{ needs.crap-typescript-gate-node-24.result }}" != "success" ]; then
+            echo "The matrix crap-typescript gate did not complete successfully." >&2
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,11 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
-  publish:
-    name: Publish Release
+  validate:
+    name: Validate Release
     runs-on: ubuntu-latest
 
     steps:
@@ -24,7 +23,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24"
-          registry-url: "https://registry.npmjs.org"
           cache: npm
 
       - name: Set up npm 11.14.1
@@ -42,26 +40,63 @@ jobs:
       - name: Run build and tests
         run: npm test
 
-      # Trusted Publishing uses the job OIDC token for auth and npm
-      # automatically emits provenance for public packages from public repos.
-      - name: Publish core
-        run: npm publish --workspace packages/core --access public
+      - name: Run cognitive-typescript gate
+        run: npm run cognitive-typescript-check
 
-      - name: Publish CLI
-        run: npm publish --workspace packages/cli --access public
+      - name: Run crap-typescript gate
+        run: npm run crap-typescript-check
 
-      - name: Publish Vitest adapter
-        run: npm publish --workspace packages/vitest --access public
+      - name: Build publish artifacts
+        run: |
+          mkdir -p release-artifacts
+          npm run build
+          npm pack --workspaces --pack-destination release-artifacts
+          cp release-notes.md release-artifacts/release-notes.md
 
-      - name: Publish Jest adapter
-        run: npm publish --workspace packages/jest --access public
+      - name: Upload publish artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: release-artifacts/
+          if-no-files-found: error
+
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: validate
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Set up Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download publish artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: release-artifacts
+
+      - name: Publish packages
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          npm publish "release-artifacts/barney-media-cognitive-typescript-core-${version}.tgz" --access public
+          npm publish "release-artifacts/barney-media-cognitive-typescript-${version}.tgz" --access public
+          npm publish "release-artifacts/barney-media-cognitive-typescript-vitest-${version}.tgz" --access public
+          npm publish "release-artifacts/barney-media-cognitive-typescript-jest-${version}.tgz" --access public
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-artifacts/release-notes.md
           else
-            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
+            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-artifacts/release-notes.md
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node 24
+      - name: Set up Node 24.0.0
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "24.0.0"
           cache: npm
 
       - name: Set up npm 11.14.1
@@ -37,19 +37,21 @@ jobs:
       - name: Render release notes
         run: node ./scripts/render-release-notes.mjs "${GITHUB_REF_NAME}" > release-notes.md
 
-      - name: Run build and tests
-        run: npm test
+      - name: Build packages
+        run: npm run build
+
+      - name: Run tests
+        run: node ./node_modules/vitest/vitest.mjs run
 
       - name: Run cognitive-typescript gate
         run: npm run cognitive-typescript-check
 
       - name: Run crap-typescript gate
-        run: npm run crap-typescript-check
+        run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts
 
       - name: Build publish artifacts
         run: |
           mkdir -p release-artifacts
-          npm run build
           npm pack --workspaces --pack-destination release-artifacts
           cp release-notes.md release-artifacts/release-notes.md
 
@@ -69,11 +71,14 @@ jobs:
       id-token: write
 
     steps:
-      - name: Set up Node 24
+      - name: Set up Node 24.0.0
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "24.0.0"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
 
       - name: Download publish artifacts
         uses: actions/download-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,22 @@ All changes in this repository are expected to be issue-linked.
 5. Keep the pull request green, reply to review comments, and resolve threads only after the fix or an explicit invalidation response.
 6. Merge only after the latest review is newer than the latest push and all required checks are green.
 
+## Local validation
+
+Run the same command set the CI workflow enforces before pushing:
+
+```bash
+npm ci
+npm run build
+npm test
+npm run cognitive-typescript-check
+npm run crap-typescript-check
+npm pack --workspaces
+```
+
+Before tagging a release, also run:
+
+```bash
+npm run verify-release-version -- v0.1.1
+```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ All changes in this repository are expected to be issue-linked.
 
 ## Local validation
 
-Run the same command set the CI workflow enforces before pushing:
+Run the full Ubuntu validation command set before pushing. CI also runs Windows build/test coverage separately to catch path and platform issues:
 
 ```bash
 npm ci

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ It performs pure static analysis using the Sonar Cognitive Complexity white pape
 
 ## Build and Test
 
+CI validates the repository on Ubuntu and Windows with Node `22.12.0` and `24.0.0`. Locally, run the same command set before opening or updating a pull request:
+
 ```bash
 npm ci
 npm run build
@@ -108,7 +110,7 @@ Verified and unverified syntax shapes are tracked in [docs/compatibility-matrix.
 
 ## Release
 
-The default release path uses npm Trusted Publishing from `.github/workflows/release.yml`. Tag `v<version>` from `main` after the build workflow is green. The tag-triggered release workflow verifies package versions, renders the GitHub release notes from `CHANGELOG.md`, publishes the four public npm packages, and creates the GitHub release.
+The default release path uses npm Trusted Publishing from `.github/workflows/release.yml`. Tag `v<version>` from `main` after the build workflow is green. The tag-triggered release workflow verifies package versions, renders the GitHub release notes from `CHANGELOG.md`, runs `npm test`, `npm run cognitive-typescript-check`, and `npm run crap-typescript-check`, then publishes the four public npm packages and creates the GitHub release.
 
 `v0.1.0` was the one-time bootstrap release that used the GitHub repo `NPM_TOKEN` secret together with provenance so the package names could be created on npm. Trusted Publishers are now the default for these packages:
 
@@ -123,6 +125,12 @@ Release notes can be rendered locally with:
 
 ```bash
 npm run render-release-notes -- v0.1.1
+```
+
+Before tagging a release, also verify the version metadata locally:
+
+```bash
+npm run verify-release-version -- v0.1.1
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It performs pure static analysis using the Sonar Cognitive Complexity white pape
 
 ## Build and Test
 
-CI validates the repository on Ubuntu and Windows with Node `22.12.0` and `24.0.0`. Locally, run the same command set before opening or updating a pull request:
+CI validates the repository on Ubuntu and Windows with Node `22.12.0` and `24.0.0`. Ubuntu enforces the full build, test, gate, and packaging command set; Windows independently validates build/test behavior. Locally, run the full Ubuntu command set before opening or updating a pull request:
 
 ```bash
 npm ci


### PR DESCRIPTION
Closes #22

## Summary
- add Ubuntu and Windows CI coverage for Node 22.12.0 and 24.0.0
- keep cognitive and CRAP gates explicit in CI, with isolated CRAP gate installs instead of fragile cross-job workspace handoff
- split release validation from privileged publishing and require both gates before publication

## Validation
- npm ci
- npm run build
- npm test
- npm run cognitive-typescript-check
- npm run crap-typescript-check
- npm pack --workspaces
- npm run verify-release-version -- v0.1.1