### PR TITLE
Strengthen TypeScript CI and release gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,17 +166,3 @@ jobs:
       - name: Run crap-typescript gate
         run: npm run crap-typescript-check
 
-  crap-typescript-gate-required:
-    name: crap-typescript Gate
-    runs-on: ubuntu-latest
-    needs: [crap-typescript-gate-node-22, crap-typescript-gate-node-24]
-    if: ${{ always() }}
-
-    steps:
-      - name: Require the matrix CRAP gate to pass
-        shell: bash
-        run: |
-          if [ "${{ needs.crap-typescript-gate-node-22.result }}" != "success" ] || [ "${{ needs.crap-typescript-gate-node-24.result }}" != "success" ]; then
-            echo "The matrix crap-typescript gate did not complete successfully." >&2
-            exit 1
-          fi


### PR DESCRIPTION
Closes #22

Supersedes #33 because GitHub stopped advancing that PR against the live branch head, so new pushes, check contexts, and review requests were no longer attached to the actual branch tip.

## Summary
- add Ubuntu and Windows CI coverage for Node 22.12.0 and 24.0.0
- keep cognitive and CRAP gates explicit in CI, with isolated CRAP gate installs instead of fragile cross-job workspace handoff
- split release validation from privileged publishing and require both gates before publication
- remove the synthetic plain `crap-typescript Gate` aggregator and rely on the real matrix gate contexts directly

## Validation
- npm ci
- npm run build
- npm test
- npm run cognitive-typescript-check
- npm run crap-typescript-check
- npm pack --workspaces
- npm run verify-release-version -- v0.1.1