### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
+- No unreleased changes.
+
+## [0.2.0] - 2026-05-24
+
 ### Added
 
 - Added aligned CLI, core API, Jest, and Vitest report controls for primary reports, JUnit sidecars, compact agent output, and configurable thresholds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ CI expectations for pull requests:
 Before tagging a release, also run:
 
 ```bash
-npm run verify-release-version -- v0.1.1
+npm run verify-release-version -- v0.2.0
 ```
 
 The release workflow also renders the GitHub release notes from `CHANGELOG.md`, so unreleased notes need to be kept current before tagging.

--- a/README.md
+++ b/README.md
@@ -302,18 +302,18 @@ The default release path uses npm Trusted Publishing from `.github/workflows/rel
 - `@barney-media/cognitive-typescript-vitest`
 - `@barney-media/cognitive-typescript-jest`
 
-After `v0.1.1` publishes successfully via Trusted Publishing, remove the GitHub repo `NPM_TOKEN` secret.
+The earlier `v0.1.0` bootstrap used a one-time `NPM_TOKEN` secret so the public package names could be created. Trusted Publishing is now the default path and does not require that token.
 
 Release notes can be rendered locally with:
 
 ```bash
-npm run render-release-notes -- v0.1.1
+npm run render-release-notes -- v0.2.0
 ```
 
 Before tagging a release, also verify the version metadata locally:
 
 ```bash
-npm run verify-release-version -- v0.1.1
+npm run verify-release-version -- v0.2.0
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cognitive-typescript-parent",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cognitive-typescript-parent",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -6653,10 +6653,10 @@
     },
     "packages/cli": {
       "name": "@barney-media/cognitive-typescript",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.1.1"
+        "@barney-media/cognitive-typescript-core": "^0.2.0"
       },
       "bin": {
         "cognitive-typescript": "dist/bin.js"
@@ -6667,7 +6667,7 @@
     },
     "packages/core": {
       "name": "@barney-media/cognitive-typescript-core",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.7.2",
@@ -6679,10 +6679,10 @@
     },
     "packages/jest": {
       "name": "@barney-media/cognitive-typescript-jest",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.1.1"
+        "@barney-media/cognitive-typescript-core": "^0.2.0"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -6693,10 +6693,10 @@
     },
     "packages/vitest": {
       "name": "@barney-media/cognitive-typescript-vitest",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.1.1"
+        "@barney-media/cognitive-typescript-core": "^0.2.0"
       },
       "engines": {
         "node": ">=22.13.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cognitive-typescript-parent",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Cognitive Complexity metrics for TypeScript",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "CLI for Cognitive Complexity analysis in TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -42,6 +42,6 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.1.1"
+    "@barney-media/cognitive-typescript-core": "^0.2.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-core",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Core Cognitive Complexity analyzer for TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-jest",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Jest integration for cognitive-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -42,7 +42,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.1.1"
+    "@barney-media/cognitive-typescript-core": "^0.2.0"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-vitest",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Vitest integration for cognitive-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -38,7 +38,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.1.1"
+    "@barney-media/cognitive-typescript-core": "^0.2.0"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- prepare the v0.2.0 release metadata and package versions
- roll the current unreleased mainline delta into the 2026-05-24 changelog entry
- update versioned release examples in README and CONTRIBUTING

## Validation
- npm ci
- npm run build
- npm run lint
- npm test
- npm run cognitive-typescript-check
- npm run crap-typescript-check
- npm run verify-release-version -- v0.2.0
- npm run render-release-notes -- v0.2.0
- npm pack --workspaces

## Note
- local Windows Prettier --check reports repository-wide formatting drift on unchanged files; GitHub's Ubuntu workflow is the release gate for that check.