### PR TITLE
Fix release tarball publish paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,10 @@ jobs:
         run: |
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
-          npm publish "release-artifacts/barney-media-cognitive-typescript-core-${version}.tgz" --access public
-          npm publish "release-artifacts/barney-media-cognitive-typescript-${version}.tgz" --access public
-          npm publish "release-artifacts/barney-media-cognitive-typescript-vitest-${version}.tgz" --access public
-          npm publish "release-artifacts/barney-media-cognitive-typescript-jest-${version}.tgz" --access public
+          npm publish "./release-artifacts/barney-media-cognitive-typescript-core-${version}.tgz" --access public
+          npm publish "./release-artifacts/barney-media-cognitive-typescript-${version}.tgz" --access public
+          npm publish "./release-artifacts/barney-media-cognitive-typescript-vitest-${version}.tgz" --access public
+          npm publish "./release-artifacts/barney-media-cognitive-typescript-jest-${version}.tgz" --access public
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
## Summary
- prefix the release tarball paths with ./ so npm publish treats them as local files
- keep the fix scoped to the release workflow only

## Validation
- npm publish ./barney-media-cognitive-typescript-core-0.2.0.tgz --dry-run