### PR TITLE
chore(deps): update compatible npm tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
         run: npm run build
 
       - name: Download coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: coverage
           path: coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "24.0.0"
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
           node-version: "24.0.0"
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -84,7 +84,7 @@ jobs:
           node-version: "24.0.0"
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -113,7 +113,7 @@ jobs:
           node-version: "24.0.0"
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -148,7 +148,7 @@ jobs:
           node-version: "24.0.0"
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -49,7 +49,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -61,7 +61,7 @@ jobs:
         run: npm test
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage
@@ -85,7 +85,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -114,7 +114,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -123,7 +123,7 @@ jobs:
         run: npm run build
 
       - name: Download coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage
           path: coverage
@@ -149,7 +149,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -62,7 +62,7 @@ jobs:
           cp release-notes.md release-artifacts/release-notes.md
 
       - name: Upload publish artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-artifacts
           path: release-artifacts/
@@ -84,10 +84,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Download publish artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-artifacts
           path: release-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "24.0.0"
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -83,7 +83,7 @@ jobs:
           node-version: "24.0.0"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Download publish artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         run: npm install --global npm@11.15.0
 
       - name: Download publish artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: release-artifacts
           path: release-artifacts

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "packageManager": "npm@11.14.1",
+  "packageManager": "npm@11.15.0",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
Closes #44## Summary- Updates npm packageManager/workflow installer and artifact actions.- Preserves Node >=22.13.0 and leaves test fixture manifests unchanged.## Validation- npx npm@11.15.0 ci; npx npm@11.15.0 run build; npx npm@11.15.0 test; npx npm@11.15.0 run lint; npx npm@11.15.0 run pack. Local Windows format:check hit broad CRLF differences; remote Linux CI is the format gate.## Review Notes- Dependency-only change; no public runtime floor was raised.- Latest-compatible versions were selected over latest-absolute releases when framework or runtime constraints required it.