### PR TITLE
Harden function discovery naming

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -15,6 +15,7 @@ This matrix records the TypeScript syntax and Cognitive Complexity behaviors cur
 | Expression-bodied arrows and declaration-only bodies | `tests/fixtures/compatibility-matrix/expression-and-declarations` | Verifies expression bodies score correctly and declaration-only bodies stay at `0`. |
 | Class and object methods | `tests/fixtures/compatibility-matrix/object-and-class-methods` | Verifies both container forms are discovered and named consistently. |
 | Property-assigned functions | `tests/fixtures/compatibility-matrix/property-assigned-functions` | Verifies class-field arrows, property access assignments, and element access assignments. |
+| Function discovery hardening | `tests/fixtures/compatibility-matrix/function-discovery-hardening` | Verifies namespace/class/object owner chains, class-field object owners, and static element-access assignment names. |
 | Ambient and namespace-only declaration containers | `tests/fixtures/compatibility-matrix/ambient-and-namespace-only` | Verifies declaration-only containers are ignored without inventing functions. |
 | Nested functions | `tests/fixtures/compatibility-matrix/nested-functions` | Verifies nested functions are scored independently and do not contribute to their enclosing function. |
 | Faux-class wrappers | `tests/fixtures/compatibility-matrix/faux-class-wrapper` | Verifies top-level declarative wrappers do not suppress legitimate exported property-assigned functions. |

--- a/packages/core/src/analysisModel.ts
+++ b/packages/core/src/analysisModel.ts
@@ -50,4 +50,6 @@ export type NamedFunctionLike =
   | ts.FunctionExpression
   | ts.ArrowFunction;
 
+export type BodyBearingNamedFunctionLike = NamedFunctionLike & { body: ts.ConciseBody };
+
 export type LogicalOperator = "&&" | "||" | null;

--- a/packages/core/src/cognitiveComplexity.ts
+++ b/packages/core/src/cognitiveComplexity.ts
@@ -1,9 +1,10 @@
 import ts from "typescript";
 
-import type { CallTarget, LogicalOperator, NamedFunctionLike } from "./analysisModel";
+import type { BodyBearingNamedFunctionLike, CallTarget, LogicalOperator, NamedFunctionLike } from "./analysisModel";
+import { staticElementAccessName, staticExpressionName } from "./staticNames";
 
 export function analyzeFunctionBody(
-  root: NamedFunctionLike,
+  root: BodyBearingNamedFunctionLike,
   sourceFile: ts.SourceFile,
   checker: ts.TypeChecker,
   containerName: string | null
@@ -53,7 +54,7 @@ export function analyzeFunctionBody(
   const recordCall = (expression: ts.Expression, arity: number): void => {
     calls.push({
       symbol: resolveCallSymbol(expression, checker),
-      ...fallbackCallTarget(expression, sourceFile, containerName),
+      ...fallbackCallTarget(expression, containerName),
       arity
     });
   };
@@ -292,13 +293,12 @@ function resolveSymbol(node: ts.Node, checker: ts.TypeChecker): ts.Symbol | null
 
 function fallbackCallTarget(
   expression: ts.Expression,
-  sourceFile: ts.SourceFile,
   containerName: string | null
 ): Pick<CallTarget, "name" | "ownerName"> {
   return (
     resolveIdentifierCallTarget(expression) ??
-    resolvePropertyAccessCallTarget(expression, sourceFile, containerName) ??
-    resolveElementAccessCallTarget(expression, sourceFile, containerName) ?? { name: null, ownerName: null }
+    resolvePropertyAccessCallTarget(expression, containerName) ??
+    resolveElementAccessCallTarget(expression, containerName) ?? { name: null, ownerName: null }
   );
 }
 
@@ -313,35 +313,33 @@ function resolveIdentifierCallTarget(expression: ts.Expression): Pick<CallTarget
 
 function resolvePropertyAccessCallTarget(
   expression: ts.Expression,
-  sourceFile: ts.SourceFile,
   containerName: string | null
 ): Pick<CallTarget, "name" | "ownerName"> | null {
   return ts.isPropertyAccessExpression(expression)
     ? {
         name: expression.name.text,
-        ownerName: ownerText(expression.expression, sourceFile, containerName)
+        ownerName: ownerText(expression.expression, containerName)
       }
     : null;
 }
 
 function resolveElementAccessCallTarget(
   expression: ts.Expression,
-  sourceFile: ts.SourceFile,
   containerName: string | null
 ): Pick<CallTarget, "name" | "ownerName"> | null {
-  return ts.isElementAccessExpression(expression) && expression.argumentExpression
+  const name = ts.isElementAccessExpression(expression)
+    ? staticElementAccessName(expression.argumentExpression)
+    : null;
+  return ts.isElementAccessExpression(expression) && name
     ? {
-        name: `[${expression.argumentExpression.getText(sourceFile)}]`,
-        ownerName: ownerText(expression.expression, sourceFile, containerName)
+        name,
+        ownerName: ownerText(expression.expression, containerName)
       }
     : null;
 }
 
-function ownerText(expression: ts.Expression, sourceFile: ts.SourceFile, containerName: string | null): string | null {
-  if (expression.kind === ts.SyntaxKind.ThisKeyword || expression.kind === ts.SyntaxKind.SuperKeyword) {
-    return containerName;
-  }
-  return expression.getText(sourceFile);
+function ownerText(expression: ts.Expression, containerName: string | null): string | null {
+  return staticExpressionName(expression, containerName);
 }
 
 function logicalOperator(kind: ts.SyntaxKind): "&&" | "||" | "??" | null {

--- a/packages/core/src/functionDiscovery.ts
+++ b/packages/core/src/functionDiscovery.ts
@@ -1,7 +1,8 @@
 import ts from "typescript";
 
 import { analyzeFunctionBody, isNestedFunctionLike } from "./cognitiveComplexity";
-import type { InternalMethod, NamedFunctionLike } from "./analysisModel";
+import type { BodyBearingNamedFunctionLike, InternalMethod, NamedFunctionLike } from "./analysisModel";
+import { anonymousName, stablePropertyName, staticElementAccessName, staticExpressionName } from "./staticNames";
 import type { SourceSpan } from "./types";
 import { normalizeSlashes } from "./utils";
 
@@ -45,7 +46,7 @@ function buildFunctionDeclarationMethod(
   sourceFile: ts.SourceFile,
   checker: ts.TypeChecker
 ): InternalMethod | null {
-  if (!ts.isFunctionDeclaration(node) || !node.body) {
+  if (!ts.isFunctionDeclaration(node) || !hasFunctionBody(node)) {
     return null;
   }
   const functionName = node.name?.text ?? inferAnonymousDefaultName(node);
@@ -57,7 +58,7 @@ function buildFunctionDeclarationMethod(
     sourceFile,
     checker,
     functionName,
-    containerName: findContainerName(node),
+    containerName: findContainerName(node, sourceFile),
     symbolNodes: node.name ? [node.name] : []
   });
 }
@@ -67,10 +68,10 @@ function buildConstructorMethod(
   sourceFile: ts.SourceFile,
   checker: ts.TypeChecker
 ): InternalMethod | null {
-  if (!ts.isConstructorDeclaration(node) || !node.body) {
+  if (!ts.isConstructorDeclaration(node) || !hasFunctionBody(node)) {
     return null;
   }
-  const containerName = findContainerName(node);
+  const containerName = findContainerName(node, sourceFile);
   if (!containerName) {
     return null;
   }
@@ -89,29 +90,29 @@ function buildMethodDeclarationMethod(
   sourceFile: ts.SourceFile,
   checker: ts.TypeChecker
 ): InternalMethod | null {
-  if (!ts.isMethodDeclaration(node) || !node.body) {
+  if (!ts.isMethodDeclaration(node) || !hasFunctionBody(node)) {
     return null;
   }
   return createInternalMethod({
     functionNode: node,
     sourceFile,
     checker,
-    functionName: propertyName(node.name),
-    containerName: findContainerName(node),
+    functionName: propertyName(node.name, sourceFile),
+    containerName: findContainerName(node, sourceFile),
     symbolNodes: [node.name]
   });
 }
 
 function buildAccessorMethod(node: ts.Node, sourceFile: ts.SourceFile, checker: ts.TypeChecker): InternalMethod | null {
-  if (!(ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) || !node.body) {
+  if (!(ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) || !hasFunctionBody(node)) {
     return null;
   }
   return createInternalMethod({
     functionNode: node,
     sourceFile,
     checker,
-    functionName: `${ts.isGetAccessorDeclaration(node) ? "get" : "set"} ${propertyName(node.name)}`,
-    containerName: findContainerName(node),
+    functionName: `${ts.isGetAccessorDeclaration(node) ? "get" : "set"} ${propertyName(node.name, sourceFile)}`,
+    containerName: findContainerName(node, sourceFile),
     symbolNodes: [node.name]
   });
 }
@@ -121,17 +122,12 @@ function buildAssignedFunctionMethod(
   sourceFile: ts.SourceFile,
   checker: ts.TypeChecker
 ): InternalMethod | null {
-  if (!(ts.isFunctionExpression(node) || ts.isArrowFunction(node))) {
+  if (!(ts.isFunctionExpression(node) || ts.isArrowFunction(node)) || !hasFunctionBody(node)) {
     return null;
   }
-  const assignment = findAssignedFunctionName(node);
+  const assignment = findAssignedFunctionName(node, sourceFile);
   if (!assignment) {
     return null;
-  }
-
-  const symbolNodes = [...assignment.symbolNodes];
-  if (ts.isFunctionExpression(node) && node.name) {
-    symbolNodes.push(node.name);
   }
 
   return createInternalMethod({
@@ -140,10 +136,19 @@ function buildAssignedFunctionMethod(
     checker,
     functionName: assignment.name,
     containerName: assignment.containerName,
-    symbolNodes,
+    symbolNodes: assignedFunctionSymbolNodes(node, assignment.symbolNodes),
     fallbackOwnerName: assignment.fallbackOwnerName,
     fallbackNames: assignment.fallbackNames
   });
+}
+
+function assignedFunctionSymbolNodes(
+  node: ts.FunctionExpression | ts.ArrowFunction,
+  assignmentSymbolNodes: ts.Node[]
+): ts.Node[] {
+  return ts.isFunctionExpression(node) && node.name
+    ? [...assignmentSymbolNodes, node.name]
+    : [...assignmentSymbolNodes];
 }
 
 function createInternalMethod({
@@ -156,7 +161,7 @@ function createInternalMethod({
   fallbackOwnerName,
   fallbackNames
 }: {
-  functionNode: NamedFunctionLike;
+  functionNode: BodyBearingNamedFunctionLike;
   sourceFile: ts.SourceFile;
   checker: ts.TypeChecker;
   functionName: string;
@@ -165,7 +170,7 @@ function createInternalMethod({
   fallbackOwnerName?: string | null;
   fallbackNames?: string[];
 }): InternalMethod {
-  const body = functionNode.body!;
+  const body = functionNode.body;
   const bodySpan = toSourceSpan(body, sourceFile);
   const startLine = sourceFile.getLineAndCharacterOfPosition(functionNode.getStart(sourceFile)).line + 1;
   const endLine = sourceFile.getLineAndCharacterOfPosition(Math.max(body.end - 1, body.getStart(sourceFile))).line + 1;
@@ -273,7 +278,7 @@ function inferAnonymousDefaultName(node: ts.FunctionDeclaration): string | null 
   return node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword) ? "default" : null;
 }
 
-function findAssignedFunctionName(node: ts.FunctionExpression | ts.ArrowFunction): {
+function findAssignedFunctionName(node: ts.FunctionExpression | ts.ArrowFunction, sourceFile: ts.SourceFile): {
   name: string;
   containerName: string | null;
   symbolNodes: ts.Node[];
@@ -282,7 +287,7 @@ function findAssignedFunctionName(node: ts.FunctionExpression | ts.ArrowFunction
 } | null {
   const parent = node.parent;
   for (const resolver of ASSIGNED_FUNCTION_NAME_RESOLVERS) {
-    const assignment = resolver(parent, node);
+    const assignment = resolver(parent, node, sourceFile);
     if (assignment) {
       return assignment;
     }
@@ -292,7 +297,8 @@ function findAssignedFunctionName(node: ts.FunctionExpression | ts.ArrowFunction
 
 type AssignedFunctionNameResolver = (
   parent: ts.Node,
-  node: ts.FunctionExpression | ts.ArrowFunction
+  node: ts.FunctionExpression | ts.ArrowFunction,
+  sourceFile: ts.SourceFile
 ) => {
   name: string;
   containerName: string | null;
@@ -308,9 +314,13 @@ const ASSIGNED_FUNCTION_NAME_RESOLVERS: AssignedFunctionNameResolver[] = [
   assignedNameFromBinaryExpression
 ];
 
-function assignedNameFromVariableDeclaration(parent: ts.Node): ReturnType<AssignedFunctionNameResolver> {
+function assignedNameFromVariableDeclaration(
+  parent: ts.Node,
+  _node: ts.FunctionExpression | ts.ArrowFunction,
+  sourceFile: ts.SourceFile
+): ReturnType<AssignedFunctionNameResolver> {
   if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
-    const containerName = findContainerName(parent);
+    const containerName = findContainerName(parent, sourceFile);
     return {
       name: parent.name.text,
       containerName,
@@ -322,10 +332,14 @@ function assignedNameFromVariableDeclaration(parent: ts.Node): ReturnType<Assign
   return null;
 }
 
-function assignedNameFromPropertyAssignment(parent: ts.Node): ReturnType<AssignedFunctionNameResolver> {
+function assignedNameFromPropertyAssignment(
+  parent: ts.Node,
+  _node: ts.FunctionExpression | ts.ArrowFunction,
+  sourceFile: ts.SourceFile
+): ReturnType<AssignedFunctionNameResolver> {
   if (ts.isPropertyAssignment(parent)) {
-    const name = propertyName(parent.name);
-    const containerName = inferObjectContainerName(parent.parent);
+    const name = propertyName(parent.name, sourceFile);
+    const containerName = inferObjectContainerName(parent.parent, sourceFile);
     return {
       name,
       containerName,
@@ -337,10 +351,14 @@ function assignedNameFromPropertyAssignment(parent: ts.Node): ReturnType<Assigne
   return null;
 }
 
-function assignedNameFromPropertyDeclaration(parent: ts.Node): ReturnType<AssignedFunctionNameResolver> {
+function assignedNameFromPropertyDeclaration(
+  parent: ts.Node,
+  _node: ts.FunctionExpression | ts.ArrowFunction,
+  sourceFile: ts.SourceFile
+): ReturnType<AssignedFunctionNameResolver> {
   if (ts.isPropertyDeclaration(parent)) {
-    const name = propertyName(parent.name);
-    const containerName = findContainerName(parent);
+    const name = propertyName(parent.name, sourceFile);
+    const containerName = findContainerName(parent, sourceFile);
     return {
       name,
       containerName,
@@ -354,14 +372,15 @@ function assignedNameFromPropertyDeclaration(parent: ts.Node): ReturnType<Assign
 
 function assignedNameFromBinaryExpression(
   parent: ts.Node,
-  node: ts.FunctionExpression | ts.ArrowFunction
+  node: ts.FunctionExpression | ts.ArrowFunction,
+  sourceFile: ts.SourceFile
 ): ReturnType<AssignedFunctionNameResolver> {
   if (
     !(ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken && parent.right === node)
   ) {
     return null;
   }
-  const target = assignmentTarget(parent.left);
+  const target = assignmentTarget(parent.left, sourceFile);
   return {
     name: target.name,
     containerName: target.containerName,
@@ -371,21 +390,26 @@ function assignedNameFromBinaryExpression(
   };
 }
 
-function findContainerName(node: ts.Node): string | null {
+function findContainerName(node: ts.Node, sourceFile: ts.SourceFile): string | null {
+  const segments: string[] = [];
   let current: ts.Node | undefined = node.parent;
   while (current) {
-    const containerName = containerNameFromNode(current);
-    if (containerName) {
-      return containerName;
+    if (ts.isObjectLiteralExpression(current)) {
+      const objectName = inferObjectContainerName(current, sourceFile);
+      return segments.length ? toDisplayName(objectName, segments.join(".")) : objectName;
+    }
+    const segment = containerSegmentFromNode(current);
+    if (segment) {
+      segments.unshift(segment);
     }
     current = current.parent;
   }
-  return null;
+  return segments.length ? segments.join(".") : null;
 }
 
-function inferObjectContainerName(node: ts.ObjectLiteralExpression): string | null {
+function inferObjectContainerName(node: ts.ObjectLiteralExpression, sourceFile: ts.SourceFile): string | null {
   for (const resolver of OBJECT_CONTAINER_RESOLVERS) {
-    const containerName = resolver(node.parent);
+    const containerName = resolver(node.parent, sourceFile);
     if (containerName) {
       return containerName;
     }
@@ -393,7 +417,7 @@ function inferObjectContainerName(node: ts.ObjectLiteralExpression): string | nu
   return null;
 }
 
-type ObjectContainerResolver = (parent: ts.Node) => string | null;
+type ObjectContainerResolver = (parent: ts.Node, sourceFile: ts.SourceFile) => string | null;
 
 const OBJECT_CONTAINER_RESOLVERS: ObjectContainerResolver[] = [
   containerFromVariableDeclaration,
@@ -402,56 +426,53 @@ const OBJECT_CONTAINER_RESOLVERS: ObjectContainerResolver[] = [
   containerFromBinaryAssignment
 ];
 
-function containerFromVariableDeclaration(parent: ts.Node): string | null {
+function containerFromVariableDeclaration(parent: ts.Node, sourceFile: ts.SourceFile): string | null {
   if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
-    return parent.name.text;
+    return toDisplayName(findContainerName(parent, sourceFile), parent.name.text);
   }
   return null;
 }
 
-function containerFromPropertyAssignment(parent: ts.Node): string | null {
+function containerFromPropertyAssignment(parent: ts.Node, sourceFile: ts.SourceFile): string | null {
   if (ts.isPropertyAssignment(parent)) {
-    return propertyName(parent.name);
+    return toDisplayName(inferObjectContainerName(parent.parent, sourceFile), propertyName(parent.name, sourceFile));
   }
   return null;
 }
 
-function containerFromPropertyDeclaration(parent: ts.Node): string | null {
+function containerFromPropertyDeclaration(parent: ts.Node, sourceFile: ts.SourceFile): string | null {
   if (ts.isPropertyDeclaration(parent)) {
-    return propertyName(parent.name);
+    return toDisplayName(findContainerName(parent, sourceFile), propertyName(parent.name, sourceFile));
   }
   return null;
 }
 
-function containerFromBinaryAssignment(parent: ts.Node): string | null {
+function containerFromBinaryAssignment(parent: ts.Node, sourceFile: ts.SourceFile): string | null {
   if (!isAssignmentBinaryExpression(parent)) {
     return null;
   }
-  const target = assignmentTarget(parent.left);
+  const target = assignmentTarget(parent.left, sourceFile);
   return toDisplayName(target.containerName, target.name);
 }
 
-function assignmentTarget(node: ts.Expression): { name: string; containerName: string | null } {
+function assignmentTarget(node: ts.Expression, sourceFile: ts.SourceFile): { name: string; containerName: string | null } {
   for (const resolver of ASSIGNMENT_TARGET_RESOLVERS) {
-    const target = resolver(node);
+    const target = resolver(node, sourceFile);
     if (target) {
       return target;
     }
   }
-  return createAssignmentTarget("<assigned>", null);
+  return createAssignmentTarget(anonymousName(node, sourceFile), null);
 }
 
-function propertyName(name: ts.PropertyName): string {
-  if (ts.isPrivateIdentifier(name)) {
-    return name.getText();
-  }
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
-    return name.text;
-  }
-  return name.getText();
+function propertyName(name: ts.PropertyName, sourceFile: ts.SourceFile): string {
+  return stablePropertyName(name, sourceFile);
 }
 
 function toDisplayName(containerName: string | null, functionName: string): string {
+  if (!functionName) {
+    return containerName ?? "";
+  }
   if (!containerName) {
     return functionName;
   }
@@ -572,11 +593,14 @@ function isAlwaysDeclarativeStatement(statement: ts.Statement): boolean {
   return isDeclarativeTypeStatement(statement) || ts.isVariableStatement(statement) || ts.isEmptyStatement(statement);
 }
 
-function containerNameFromNode(node: ts.Node): string | null {
+function containerSegmentFromNode(node: ts.Node): string | null {
   if ((ts.isClassDeclaration(node) || ts.isClassExpression(node)) && node.name) {
     return node.name.text;
   }
-  return ts.isObjectLiteralExpression(node) ? inferObjectContainerName(node) : null;
+  if (ts.isModuleDeclaration(node) && ts.isIdentifier(node.name)) {
+    return node.name.text;
+  }
+  return null;
 }
 
 function isAssignmentBinaryExpression(node: ts.Node): node is ts.BinaryExpression {
@@ -590,7 +614,10 @@ function createAssignmentTarget(
   return { name, containerName };
 }
 
-type AssignmentTargetResolver = (node: ts.Expression) => { name: string; containerName: string | null } | null;
+type AssignmentTargetResolver = (
+  node: ts.Expression,
+  sourceFile: ts.SourceFile
+) => { name: string; containerName: string | null } | null;
 
 const ASSIGNMENT_TARGET_RESOLVERS: AssignmentTargetResolver[] = [
   assignmentTargetFromIdentifier,
@@ -598,20 +625,34 @@ const ASSIGNMENT_TARGET_RESOLVERS: AssignmentTargetResolver[] = [
   assignmentTargetFromElementAccess
 ];
 
-function assignmentTargetFromIdentifier(node: ts.Expression): { name: string; containerName: string | null } | null {
+function assignmentTargetFromIdentifier(
+  node: ts.Expression
+): { name: string; containerName: string | null } | null {
   return ts.isIdentifier(node) ? createAssignmentTarget(node.text, null) : null;
 }
 
 function assignmentTargetFromPropertyAccess(
   node: ts.Expression
 ): { name: string; containerName: string | null } | null {
-  return ts.isPropertyAccessExpression(node) ? createAssignmentTarget(node.name.text, node.expression.getText()) : null;
+  return ts.isPropertyAccessExpression(node)
+    ? createAssignmentTarget(node.name.text, staticExpressionName(node.expression))
+    : null;
 }
 
-function assignmentTargetFromElementAccess(node: ts.Expression): { name: string; containerName: string | null } | null {
+function assignmentTargetFromElementAccess(
+  node: ts.Expression,
+  sourceFile: ts.SourceFile
+): { name: string; containerName: string | null } | null {
   return ts.isElementAccessExpression(node)
-    ? createAssignmentTarget(`[${node.argumentExpression?.getText() ?? ""}]`, node.expression.getText())
+    ? createAssignmentTarget(
+        staticElementAccessName(node.argumentExpression) ?? anonymousName(node.argumentExpression ?? node, sourceFile),
+        staticExpressionName(node.expression)
+      )
     : null;
+}
+
+function hasFunctionBody(node: NamedFunctionLike): node is BodyBearingNamedFunctionLike {
+  return node.body !== undefined;
 }
 
 function isMethodLikeObjectProperty(property: ts.ObjectLiteralElementLike): boolean {

--- a/packages/core/src/staticNames.ts
+++ b/packages/core/src/staticNames.ts
@@ -1,0 +1,98 @@
+import ts from "typescript";
+
+export function stablePropertyName(name: ts.PropertyName, sourceFile: ts.SourceFile): string {
+  return staticPropertyName(name) ?? anonymousName(name, sourceFile);
+}
+
+export function staticPropertyName(name: ts.PropertyName): string | null {
+  if (ts.isPrivateIdentifier(name)) {
+    return name.escapedText.toString();
+  }
+  if (ts.isComputedPropertyName(name)) {
+    return staticComputedPropertyName(name);
+  }
+  return name.text;
+}
+
+export function staticElementAccessName(argumentExpression: ts.Expression | undefined): string | null {
+  if (!argumentExpression) {
+    return null;
+  }
+  const expression = unwrapParentheses(argumentExpression);
+  if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+    return `[${JSON.stringify(expression.text)}]`;
+  }
+  if (ts.isNumericLiteral(expression)) {
+    return `[${expression.text}]`;
+  }
+  return null;
+}
+
+export function staticExpressionName(expression: ts.Expression, thisOrSuperName: string | null = null): string | null {
+  const unwrapped = unwrapParentheses(expression);
+  return (
+    staticTerminalExpressionName(unwrapped, thisOrSuperName) ??
+    staticPropertyAccessExpressionName(unwrapped, thisOrSuperName) ??
+    staticElementAccessExpressionName(unwrapped, thisOrSuperName)
+  );
+}
+
+export function anonymousName(node: ts.Node, sourceFile: ts.SourceFile): string {
+  const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  return `anonymous@${position.line + 1}:${position.character + 1}`;
+}
+
+function staticComputedPropertyName(name: ts.ComputedPropertyName): string | null {
+  const expression = unwrapParentheses(name.expression);
+  if (ts.isIdentifier(expression)) {
+    return `[${expression.text}]`;
+  }
+  return staticElementAccessName(expression);
+}
+
+function staticTerminalExpressionName(expression: ts.Expression, thisOrSuperName: string | null): string | null {
+  if (ts.isIdentifier(expression)) {
+    return expression.text;
+  }
+  return isThisOrSuperKeyword(expression) ? thisOrSuperName : null;
+}
+
+function staticPropertyAccessExpressionName(
+  expression: ts.Expression,
+  thisOrSuperName: string | null
+): string | null {
+  return ts.isPropertyAccessExpression(expression)
+    ? joinName(staticExpressionName(expression.expression, thisOrSuperName), expression.name.text)
+    : null;
+}
+
+function staticElementAccessExpressionName(
+  expression: ts.Expression,
+  thisOrSuperName: string | null
+): string | null {
+  return ts.isElementAccessExpression(expression)
+    ? joinName(
+        staticExpressionName(expression.expression, thisOrSuperName),
+        staticElementAccessName(expression.argumentExpression)
+      )
+    : null;
+}
+
+function joinName(ownerName: string | null, memberName: string | null): string | null {
+  if (!(ownerName && memberName)) {
+    return null;
+  }
+  return memberName.startsWith("[") ? `${ownerName}${memberName}` : `${ownerName}.${memberName}`;
+}
+
+function isThisOrSuperKeyword(expression: ts.Expression): boolean {
+  return expression.kind === ts.SyntaxKind.ThisKeyword || expression.kind === ts.SyntaxKind.SuperKeyword;
+}
+
+function unwrapParentheses<T extends ts.Node>(node: T): T {
+  let current: ts.Node = node;
+  while (ts.isParenthesizedExpression(current)) {
+    current = current.expression;
+  }
+  return current as T;
+}

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -137,6 +137,168 @@ export const registry = {
     });
   });
 
+  it("keeps bodyless declarations out of concrete method discovery", async () => {
+    const projectRoot = await createTempDir("cognitive-parser-");
+    tempDirs.push(projectRoot);
+    const filePath = path.join(projectRoot, "sample.ts");
+    await writeProjectFiles(projectRoot, {
+      "sample.ts": `declare function ambient(value: string): string;
+
+export function overload(value: string): string;
+export function overload(value: number): number;
+export function overload(value: string | number): string | number {
+  if (typeof value === "string") {
+    return value;
+  }
+  return value;
+}
+
+interface Shape {
+  render(): void;
+}
+
+type Handler = {
+  run(): void;
+};
+
+abstract class Base {
+  abstract render(): void;
+
+  concrete(flag: boolean): number {
+    if (flag) {
+      return 1;
+    }
+    return 0;
+  }
+}
+`
+    });
+
+    const methods = await parseFileMethods(filePath);
+    expect(toComplexityMap(methods)).toEqual({
+      overload: 1,
+      "Base.concrete": 1
+    });
+  });
+
+  it("uses owner chains and avoids source-text names for dynamic element assignments", async () => {
+    const projectRoot = await createTempDir("cognitive-parser-");
+    tempDirs.push(projectRoot);
+    const filePath = path.join(projectRoot, "sample.ts");
+    await writeProjectFiles(projectRoot, {
+      "sample.ts": `namespace Outer {
+  export class Example {
+    field = {
+      nested: (flag: boolean): number => flag ? 1 : 0
+    };
+
+    static factory = {
+      build(flag: boolean): number {
+        if (flag) {
+          return 1;
+        }
+        return 0;
+      }
+    };
+  }
+
+  export const obj = {
+    outer: {
+      inner: function (flag: boolean): number {
+        if (flag) {
+          return 1;
+        }
+        return 0;
+      }
+    }
+  };
+}
+
+class Foo {}
+Foo.prototype.bar = function (flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+};
+Foo["literal"] = function (flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+};
+const dynamicKey = "dynamic";
+Foo[dynamicKey] = function (flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+};
+`
+    });
+
+    const methods = await parseFileMethods(filePath);
+    const complexityByName = toComplexityMap(methods);
+    expect(complexityByName).toMatchObject({
+      "Outer.Example.field.nested": 1,
+      "Outer.Example.factory.build": 1,
+      "Outer.obj.outer.inner": 1,
+      "Foo.prototype.bar": 1,
+      'Foo["literal"]': 1
+    });
+    expect(Object.keys(complexityByName)).not.toContain("Foo[dynamicKey]");
+    expect(
+      Object.entries(complexityByName).some(
+        ([displayName, cognitiveComplexity]) =>
+          displayName.startsWith("Foo.anonymous@") && cognitiveComplexity === 1
+      )
+    ).toBe(true);
+  });
+
+  it("uses assigned names for named function expressions and ignores unassigned callbacks", async () => {
+    const projectRoot = await createTempDir("cognitive-parser-");
+    tempDirs.push(projectRoot);
+    const filePath = path.join(projectRoot, "sample.ts");
+    await writeProjectFiles(projectRoot, {
+      "sample.ts": `declare function consume(callback: (flag: boolean) => number): void;
+
+export const alias = function namedAlias(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+};
+
+consume(function ignored(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+});
+`
+    });
+
+    const methods = await parseFileMethods(filePath);
+    expect(toComplexityMap(methods)).toEqual({
+      alias: 1
+    });
+  });
+
+  it("reports syntactic parse diagnostics before discovery", async () => {
+    const projectRoot = await createTempDir("cognitive-parser-");
+    tempDirs.push(projectRoot);
+    const filePath = path.join(projectRoot, "sample.ts");
+    await writeProjectFiles(projectRoot, {
+      "sample.ts": `export function broken() {
+  if (true) {
+    return 1;
+}
+`
+    });
+
+    await expect(analyzeTypeScriptFiles([filePath])).rejects.toThrow("Failed to parse TypeScript source:");
+  });
+
   it("captures leading file comments after BOM, shebang, and whitespace trivia", async () => {
     const projectRoot = await createTempDir("cognitive-parser-");
     tempDirs.push(projectRoot);

--- a/packages/core/test/staticNames.test.ts
+++ b/packages/core/test/staticNames.test.ts
@@ -1,0 +1,92 @@
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import {
+  anonymousName,
+  stablePropertyName,
+  staticElementAccessName,
+  staticExpressionName,
+  staticPropertyName
+} from "../src/staticNames";
+
+describe("static name helpers", () => {
+  it("extracts static property names without source-text fallbacks", () => {
+    const sourceFile = source(`const key = "format";
+
+class Example {
+  #secret() {}
+  value() {}
+  "quoted"() {}
+  1() {}
+  [key]() {}
+  ["literal"]() {}
+  [factory()]() {}
+}
+`);
+    const names = classMemberNames(sourceFile);
+
+    expect(staticPropertyName(names[0])).toBe("#secret");
+    expect(staticPropertyName(names[1])).toBe("value");
+    expect(staticPropertyName(names[2])).toBe("quoted");
+    expect(staticPropertyName(names[3])).toBe("1");
+    expect(staticPropertyName(names[4])).toBe("[key]");
+    expect(staticPropertyName(names[5])).toBe("[\"literal\"]");
+    expect(staticPropertyName(names[6])).toBeNull();
+    expect(stablePropertyName(names[6], sourceFile)).toMatch(/^anonymous@\d+:\d+$/);
+  });
+
+  it("extracts only static element-access names", () => {
+    expect(staticElementAccessName(undefined)).toBeNull();
+    expect(staticElementAccessName(elementArgument("target[\"literal\"]"))).toBe("[\"literal\"]");
+    expect(staticElementAccessName(elementArgument("target[`template`]"))).toBe("[\"template\"]");
+    expect(staticElementAccessName(elementArgument("target[1]"))).toBe("[1]");
+    expect(staticElementAccessName(elementArgument("target[(\"wrapped\")]"))).toBe("[\"wrapped\"]");
+    expect(staticElementAccessName(elementArgument("target[key]"))).toBeNull();
+  });
+
+  it("builds static expression names and rejects dynamic owners", () => {
+    expect(staticExpressionName(expression("target"))).toBe("target");
+    expect(staticExpressionName(expression("this"), "Container")).toBe("Container");
+    expect(staticExpressionName(expression("target.value"))).toBe("target.value");
+    expect(staticExpressionName(expression("target[\"value\"]"))).toBe("target[\"value\"]");
+    expect(staticExpressionName(expression("target[key]"))).toBeNull();
+    expect(staticExpressionName(expression("factory().value"))).toBeNull();
+  });
+
+  it("builds stable anonymous names from source positions", () => {
+    const sourceFile = source(`class Example {
+  [factory()]() {}
+}
+`);
+    const [name] = classMemberNames(sourceFile);
+
+    expect(anonymousName(name, sourceFile)).toBe("anonymous@2:3");
+  });
+});
+
+function source(text: string): ts.SourceFile {
+  return ts.createSourceFile("sample.ts", text, ts.ScriptTarget.ES2022, true, ts.ScriptKind.TS);
+}
+
+function classMemberNames(sourceFile: ts.SourceFile): ts.PropertyName[] {
+  const classDeclaration = sourceFile.statements.find(ts.isClassDeclaration);
+  return classDeclaration?.members.flatMap((member) => member.name ? [member.name] : []) ?? [];
+}
+
+function elementArgument(text: string): ts.Expression | undefined {
+  const parsed = expression(text);
+  return ts.isElementAccessExpression(parsed) ? parsed.argumentExpression : undefined;
+}
+
+function expression(text: string): ts.Expression {
+  const sourceFile = source(`const value = ${text};`);
+  const statement = sourceFile.statements[0];
+  if (!ts.isVariableStatement(statement)) {
+    throw new Error("Expected variable statement.");
+  }
+  const initializer = statement.declarationList.declarations[0]?.initializer;
+  if (!initializer) {
+    throw new Error("Expected initializer.");
+  }
+  return initializer;
+}

--- a/spec.md
+++ b/spec.md
@@ -130,6 +130,8 @@ The parser shall use the TypeScript compiler API and discover independent functi
 - class-field arrows
 - computed names, rendered consistently such as `Container[name]`
 
+Discovered display names shall preserve deterministic owner context for concrete namespaces, classes, class fields, object literals, and static assignment targets. Owner segments shall be joined with `.`. Static computed names shall use bracket notation, such as `Container[name]` or `registry["key"]`. Dynamic computed assignment names shall not be derived from arbitrary source text; they shall use a stable anonymous positional segment such as `anonymous@<line>:<column>` under any statically known owner.
+
 The parser shall ignore:
 
 - overload signatures without bodies

--- a/tests/fixtures/compatibility-matrix/function-discovery-hardening/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/function-discovery-hardening/src/sample.ts
@@ -1,0 +1,44 @@
+export namespace N {
+  export class C {
+    method(flag: boolean): number {
+      if (flag) {
+        return 1;
+      }
+      return 0;
+    }
+  }
+
+  export const obj = {
+    outer: {
+      inner(flag: boolean): number {
+        if (flag) {
+          return 1;
+        }
+        return 0;
+      }
+    }
+  };
+}
+
+export class Holder {
+  static tools = {
+    run(flag: boolean): number {
+      if (flag) {
+        return 1;
+      }
+      return 0;
+    }
+  };
+
+  field = {
+    value: (flag: boolean): number => flag ? 1 : 0
+  };
+}
+
+export const registry: Record<string, (flag: boolean) => number> = {};
+registry["static"] = function (flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+};

--- a/tests/fixtures/compatibility-matrix/matrix.json
+++ b/tests/fixtures/compatibility-matrix/matrix.json
@@ -53,6 +53,17 @@
       ]
     },
     {
+      "name": "function discovery hardening",
+      "fixture": "compatibility-matrix/function-discovery-hardening",
+      "expectedMetrics": [
+        { "name": "N.C.method", "cognitiveComplexity": 1 },
+        { "name": "N.obj.outer.inner", "cognitiveComplexity": 1 },
+        { "name": "Holder.tools.run", "cognitiveComplexity": 1 },
+        { "name": "Holder.field.value", "cognitiveComplexity": 1 },
+        { "name": "registry[\"static\"]", "cognitiveComplexity": 1 }
+      ]
+    },
+    {
       "name": "JSX short-circuit rendering",
       "fixture": "compatibility-matrix/jsx-short-circuit",
       "expectedMetrics": [


### PR DESCRIPTION
Closes #46

## Summary
- preserve concrete owner chains across namespaces, classes, object literals, class fields, and static assignments
- replace source-text naming fallbacks with static AST-based naming helpers and stable anonymous positional names for dynamic computed assignments
- add compatibility fixtures and parser/helper tests for bodyless declarations, owner chains, static/dynamic element access, and parse diagnostics

## Review focus
- `packages/core/src/functionDiscovery.ts` owner-chain and body-bearing discovery flow
- `packages/core/src/staticNames.ts` static naming rules for property, element-access, and call-owner fallback names
- compatibility matrix expectations for existing names that must remain unchanged

## Validation
- `npm run build`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

## Residual risk
- Low: dynamic computed assignment names intentionally change from source-derived text to positional anonymous names so they remain bounded and stable.
