### PR TITLE
Document operator semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Report path validation is strict:
 
 Verified and unverified syntax shapes are tracked in [docs/compatibility-matrix.md](docs/compatibility-matrix.md). The matrix is backed by fixtures under `tests/fixtures/compatibility-matrix/`.
 
+Cognitive Complexity scoring for `&&`, `||`, `??`, optional chaining, logical assignment, and JSX short-circuit rendering is documented in [docs/operator-semantics.md](docs/operator-semantics.md).
+
 ## Release
 
 The default release path uses npm Trusted Publishing from `.github/workflows/release.yml`. Tag `v<version>` from `main` after the build workflow is green. The tag-triggered release workflow verifies package versions, renders the GitHub release notes from `CHANGELOG.md`, runs `npm test`, `npm run cognitive-typescript-check`, and `npm run crap-typescript-check`, then publishes the four public npm packages and creates the GitHub release.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -20,6 +20,7 @@ This matrix records the TypeScript syntax and Cognitive Complexity behaviors cur
 | Nested functions | `tests/fixtures/compatibility-matrix/nested-functions` | Verifies nested functions are scored independently and do not contribute to their enclosing function. |
 | Faux-class wrappers | `tests/fixtures/compatibility-matrix/faux-class-wrapper` | Verifies top-level declarative wrappers do not suppress legitimate exported property-assigned functions. |
 | Logical shorthand exclusions | `tests/fixtures/compatibility-matrix/logical-shorthand` | Verifies `??` is ignored and mixed `&&` / `||` sequences reset counting boundaries. |
+| Operator semantics | `tests/fixtures/compatibility-matrix/operator-semantics` | Verifies the documented `&&`, `||`, `??`, `?.`, logical assignment, JSX shorthand, ternary, switch/default, and nested-function rules. |
 | JSX short-circuit rendering | `tests/fixtures/compatibility-matrix/jsx-short-circuit` | Verifies JSX rendering shorthand is ignored while non-JSX logical control flow is still scored. |
 | Labeled jumps | `tests/fixtures/compatibility-matrix/labeled-jumps` | Verifies labeled `break` and `continue` add complexity. |
 | Recursion cycles | `tests/fixtures/compatibility-matrix/recursion-cycle` | Verifies direct project-local recursion cycles add the white-paper recursion increment. |
@@ -30,13 +31,23 @@ The current implementation intentionally treats these forms as shorthand and doe
 
 - optional chaining
 - nullish coalescing (`??`)
+- logical assignment (`??=`, `&&=`, `||=`)
 - JSX short-circuit rendering expressions
+
+The current implementation intentionally scores logical `&&` and `||` sequences by transition:
+
+- `a && b && c` adds one logical-operator increment
+- `a || b || c` adds one logical-operator increment
+- `a && b || c && d` adds one increment for each `&&` / `||` transition boundary
+- negated logical groups start a new sequence boundary
 
 The current implementation intentionally treats these forms as independent score roots:
 
 - nested functions
 - class-field arrow functions
 - object property-assigned functions
+
+See [Cognitive Complexity Operator Semantics](operator-semantics.md) for the cross-tool comparison and rationale.
 
 ## Unverified
 

--- a/docs/operator-semantics.md
+++ b/docs/operator-semantics.md
@@ -1,0 +1,49 @@
+# Cognitive Complexity Operator Semantics
+
+`cognitive-typescript` preserves its existing TypeScript operator semantics:
+
+- `&&` and `||` count by logical-operator transition.
+- `??`, optional chaining, and logical assignment operators are shorthand and do not add Cognitive Complexity.
+- JSX short-circuit rendering is ignored when the logical expression acts as rendering shorthand.
+- Ternaries, `switch`, and labeled jumps keep their normal Cognitive Complexity rules.
+
+## Scored Operators
+
+Logical `&&` and `||` expressions are flattened into a sequence. The first operator in a run adds `+1`; a transition between `&&` and `||` adds another `+1`; repeated operators in the same run do not add more.
+
+Examples:
+
+| Expression | Cognitive Complexity Increment |
+| --- | --- |
+| `a && b && c && d` | `+1` |
+| `a || b || c || d` | `+1` |
+| `a && b || c || d` | `+2` |
+| `a && b || c && d` | `+3` |
+
+Negated logical groups start their own sequence, so `if (a && !(b && c))` scores `+3`: one for the `if`, one for the outer `&&`, and one for the nested negated `&&`.
+
+## Free Shorthand
+
+These forms do not add Cognitive Complexity directly:
+
+| Construct | Example | Increment |
+| --- | --- | --- |
+| Optional chaining | `input?.user?.name` | `+0` |
+| Nullish coalescing | `left ?? right` | `+0` |
+| Default nullish value | `const label = value ?? ""` | `+0` |
+| Logical assignment | `a ??= b`, `a &&= b`, `a ||= b` | `+0` |
+| JSX rendering shorthand | `{ok && <Widget />}` | `+0` |
+
+If a free shorthand expression contains another scored construct, only the scored construct contributes. For example, `input.user?.name ?? (input.demo ? "demo" : "none")` scores `+1` for the ternary only.
+
+## Comparison
+
+| Tool or Rule Family | `&&` | `||` | `??` | `?.` | `??=` / `&&=` / `||=` |
+| --- | --- | --- | --- | --- | --- |
+| `cognitive-typescript` | transition | transition | free | free | free |
+| Current SonarJS | transition | free | free | free | free |
+| SonarJava / white paper | transition | transition | n/a | n/a | n/a |
+| Archived `eslint-plugin-sonarjs` | transition | transition | transition except narrow defaults | free | free |
+| Biome | transition | transition | transition | free | free |
+
+CRAP and cyclomatic tools may count some of these JavaScript constructs as branch points. That behavior is intentionally separate from Cognitive Complexity here; `switch` default-clause coverage behavior and logical-assignment branch attribution are not part of this analyzer's scoring model.

--- a/packages/core/src/cognitiveComplexity.ts
+++ b/packages/core/src/cognitiveComplexity.ts
@@ -327,9 +327,7 @@ function resolveElementAccessCallTarget(
   expression: ts.Expression,
   containerName: string | null
 ): Pick<CallTarget, "name" | "ownerName"> | null {
-  const name = ts.isElementAccessExpression(expression)
-    ? staticElementAccessName(expression.argumentExpression)
-    : null;
+  const name = ts.isElementAccessExpression(expression) ? staticElementAccessName(expression.argumentExpression) : null;
   return ts.isElementAccessExpression(expression) && name
     ? {
         name,

--- a/packages/core/src/functionDiscovery.ts
+++ b/packages/core/src/functionDiscovery.ts
@@ -278,7 +278,10 @@ function inferAnonymousDefaultName(node: ts.FunctionDeclaration): string | null 
   return node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword) ? "default" : null;
 }
 
-function findAssignedFunctionName(node: ts.FunctionExpression | ts.ArrowFunction, sourceFile: ts.SourceFile): {
+function findAssignedFunctionName(
+  node: ts.FunctionExpression | ts.ArrowFunction,
+  sourceFile: ts.SourceFile
+): {
   name: string;
   containerName: string | null;
   symbolNodes: ts.Node[];
@@ -455,7 +458,10 @@ function containerFromBinaryAssignment(parent: ts.Node, sourceFile: ts.SourceFil
   return toDisplayName(target.containerName, target.name);
 }
 
-function assignmentTarget(node: ts.Expression, sourceFile: ts.SourceFile): { name: string; containerName: string | null } {
+function assignmentTarget(
+  node: ts.Expression,
+  sourceFile: ts.SourceFile
+): { name: string; containerName: string | null } {
   for (const resolver of ASSIGNMENT_TARGET_RESOLVERS) {
     const target = resolver(node, sourceFile);
     if (target) {
@@ -625,9 +631,7 @@ const ASSIGNMENT_TARGET_RESOLVERS: AssignmentTargetResolver[] = [
   assignmentTargetFromElementAccess
 ];
 
-function assignmentTargetFromIdentifier(
-  node: ts.Expression
-): { name: string; containerName: string | null } | null {
+function assignmentTargetFromIdentifier(node: ts.Expression): { name: string; containerName: string | null } | null {
   return ts.isIdentifier(node) ? createAssignmentTarget(node.text, null) : null;
 }
 

--- a/packages/core/src/staticNames.ts
+++ b/packages/core/src/staticNames.ts
@@ -57,19 +57,13 @@ function staticTerminalExpressionName(expression: ts.Expression, thisOrSuperName
   return isThisOrSuperKeyword(expression) ? thisOrSuperName : null;
 }
 
-function staticPropertyAccessExpressionName(
-  expression: ts.Expression,
-  thisOrSuperName: string | null
-): string | null {
+function staticPropertyAccessExpressionName(expression: ts.Expression, thisOrSuperName: string | null): string | null {
   return ts.isPropertyAccessExpression(expression)
     ? joinName(staticExpressionName(expression.expression, thisOrSuperName), expression.name.text)
     : null;
 }
 
-function staticElementAccessExpressionName(
-  expression: ts.Expression,
-  thisOrSuperName: string | null
-): string | null {
+function staticElementAccessExpressionName(expression: ts.Expression, thisOrSuperName: string | null): string | null {
   return ts.isElementAccessExpression(expression)
     ? joinName(
         staticExpressionName(expression.expression, thisOrSuperName),

--- a/packages/core/test/operatorSemantics.test.ts
+++ b/packages/core/test/operatorSemantics.test.ts
@@ -1,0 +1,173 @@
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseFileMethods } from "../src/index";
+import { createTempDir, disposeTempDir, writeProjectFiles } from "./testUtils";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(disposeTempDir));
+});
+
+describe("Cognitive Complexity operator semantics", () => {
+  it("counts logical && and || by operator transition", async () => {
+    const methods = await parseSource(`
+export function andRun(a: boolean, b: boolean, c: boolean, d: boolean): boolean {
+  return a && b && c && d;
+}
+
+export function orRun(a: boolean, b: boolean, c: boolean, d: boolean): boolean {
+  return a || b || c || d;
+}
+
+export function andThenOr(a: boolean, b: boolean, c: boolean, d: boolean): boolean {
+  return a && b || c || d;
+}
+
+export function andOrAnd(a: boolean, b: boolean, c: boolean, d: boolean): boolean {
+  return a && b || c && d;
+}
+`);
+
+    expect(toComplexityMap(methods)).toEqual({
+      andRun: 1,
+      orRun: 1,
+      andThenOr: 2,
+      andOrAnd: 3
+    });
+  });
+
+  it("keeps nullish coalescing and optional chaining free", async () => {
+    const methods = await parseSource(`
+export function defaultNullish(value?: string): string {
+  const label = value ?? "";
+  return label;
+}
+
+export function nonDefaultNullish(left?: string, right?: string): string | undefined {
+  return left ?? right;
+}
+
+export function optionalAccess(input?: { user?: { name?: string } }): string | undefined {
+  return input?.user?.name;
+}
+
+export function optionalNullishTernary(input: { user?: { name?: string }; demo: boolean }): string {
+  return input.user?.name ?? (input.demo ? "demo" : "none");
+}
+`);
+
+    expect(toComplexityMap(methods)).toEqual({
+      defaultNullish: 0,
+      nonDefaultNullish: 0,
+      optionalAccess: 0,
+      optionalNullishTernary: 1
+    });
+  });
+
+  it("keeps logical assignment operators free", async () => {
+    const methods = await parseSource(`
+export function logicalAssignments(left: boolean | undefined, right: boolean): boolean | undefined {
+  left &&= right;
+  left ||= right;
+  left ??= right;
+  return left;
+}
+`);
+
+    expect(toComplexityMap(methods)).toEqual({
+      logicalAssignments: 0
+    });
+  });
+
+  it("resets logical operator sequences inside negated groups", async () => {
+    const methods = await parseSource(`
+export function negatedGroup(a: boolean, b: boolean, c: boolean): number {
+  if (a && !(b && c)) {
+    return 1;
+  }
+  return 0;
+}
+`);
+
+    expect(toComplexityMap(methods)).toEqual({
+      negatedGroup: 3
+    });
+  });
+
+  it("excludes JSX short-circuit rendering shorthand", async () => {
+    const methods = await parseSource(
+      `
+interface Props {
+  ok: boolean;
+  label: string;
+}
+
+export const Widget = ({ ok, label }: Props) => (
+  <>{ok && <strong>{label}</strong>}</>
+);
+
+export const Banner = ({ ok, label }: Props) => (
+  <>{ok && (label ? <strong>{label}</strong> : <em>none</em>)}</>
+);
+`,
+      "sample.tsx"
+    );
+
+    expect(toComplexityMap(methods)).toEqual({
+      Widget: 0,
+      Banner: 2
+    });
+  });
+
+  it("scores nested functions independently from enclosing operators", async () => {
+    const methods = await parseSource(`
+export function outer(a: boolean, b: boolean): boolean {
+  const inner = () => a && b;
+  return inner();
+}
+`);
+
+    expect(toComplexityMap(methods)).toEqual({
+      inner: 1,
+      outer: 0
+    });
+  });
+
+  it("keeps ternary and switch/default scoring separate from operator semantics", async () => {
+    const methods = await parseSource(`
+export function nestedTernary(a: boolean, b: boolean, c: boolean): number {
+  return a ? (b ? 1 : 2) : c ? 3 : 4;
+}
+
+export function switchDefault(value: string): number {
+  switch (value) {
+    default:
+      return 0;
+  }
+}
+`);
+
+    expect(toComplexityMap(methods)).toEqual({
+      nestedTernary: 5,
+      switchDefault: 1
+    });
+  });
+});
+
+async function parseSource(
+  source: string,
+  fileName = "sample.ts"
+): Promise<Awaited<ReturnType<typeof parseFileMethods>>> {
+  const projectRoot = await createTempDir("cognitive-operators-");
+  tempDirs.push(projectRoot);
+  const filePath = path.join(projectRoot, fileName);
+  await writeProjectFiles(projectRoot, { [fileName]: source });
+  return parseFileMethods(filePath);
+}
+
+function toComplexityMap(methods: Awaited<ReturnType<typeof parseFileMethods>>): Record<string, number> {
+  return Object.fromEntries(methods.map((method) => [method.displayName, method.cognitiveComplexity]));
+}

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -249,8 +249,7 @@ Foo[dynamicKey] = function (flag: boolean): number {
     expect(Object.keys(complexityByName)).not.toContain("Foo[dynamicKey]");
     expect(
       Object.entries(complexityByName).some(
-        ([displayName, cognitiveComplexity]) =>
-          displayName.startsWith("Foo.anonymous@") && cognitiveComplexity === 1
+        ([displayName, cognitiveComplexity]) => displayName.startsWith("Foo.anonymous@") && cognitiveComplexity === 1
       )
     ).toBe(true);
   });

--- a/packages/core/test/staticNames.test.ts
+++ b/packages/core/test/staticNames.test.ts
@@ -30,17 +30,17 @@ class Example {
     expect(staticPropertyName(names[2])).toBe("quoted");
     expect(staticPropertyName(names[3])).toBe("1");
     expect(staticPropertyName(names[4])).toBe("[key]");
-    expect(staticPropertyName(names[5])).toBe("[\"literal\"]");
+    expect(staticPropertyName(names[5])).toBe('["literal"]');
     expect(staticPropertyName(names[6])).toBeNull();
     expect(stablePropertyName(names[6], sourceFile)).toMatch(/^anonymous@\d+:\d+$/);
   });
 
   it("extracts only static element-access names", () => {
     expect(staticElementAccessName(undefined)).toBeNull();
-    expect(staticElementAccessName(elementArgument("target[\"literal\"]"))).toBe("[\"literal\"]");
-    expect(staticElementAccessName(elementArgument("target[`template`]"))).toBe("[\"template\"]");
+    expect(staticElementAccessName(elementArgument('target["literal"]'))).toBe('["literal"]');
+    expect(staticElementAccessName(elementArgument("target[`template`]"))).toBe('["template"]');
     expect(staticElementAccessName(elementArgument("target[1]"))).toBe("[1]");
-    expect(staticElementAccessName(elementArgument("target[(\"wrapped\")]"))).toBe("[\"wrapped\"]");
+    expect(staticElementAccessName(elementArgument('target[("wrapped")]'))).toBe('["wrapped"]');
     expect(staticElementAccessName(elementArgument("target[key]"))).toBeNull();
   });
 
@@ -48,7 +48,7 @@ class Example {
     expect(staticExpressionName(expression("target"))).toBe("target");
     expect(staticExpressionName(expression("this"), "Container")).toBe("Container");
     expect(staticExpressionName(expression("target.value"))).toBe("target.value");
-    expect(staticExpressionName(expression("target[\"value\"]"))).toBe("target[\"value\"]");
+    expect(staticExpressionName(expression('target["value"]'))).toBe('target["value"]');
     expect(staticExpressionName(expression("target[key]"))).toBeNull();
     expect(staticExpressionName(expression("factory().value"))).toBeNull();
   });
@@ -70,7 +70,7 @@ function source(text: string): ts.SourceFile {
 
 function classMemberNames(sourceFile: ts.SourceFile): ts.PropertyName[] {
   const classDeclaration = sourceFile.statements.find(ts.isClassDeclaration);
-  return classDeclaration?.members.flatMap((member) => member.name ? [member.name] : []) ?? [];
+  return classDeclaration?.members.flatMap((member) => (member.name ? [member.name] : [])) ?? [];
 }
 
 function elementArgument(text: string): ts.Expression | undefined {

--- a/spec.md
+++ b/spec.md
@@ -165,11 +165,20 @@ The analyzer shall score:
 
 The analyzer shall derive TypeScript and JavaScript behavior as follows:
 
-- optional chaining shall be ignored as shorthand
-- `??` shall be ignored as shorthand
-- mixed `&&` and `||` sequences shall reset sequence counting boundaries
+- `&&` and `||` shall be scored by logical-operator sequence transitions
+- repeated `&&` operators in the same flattened logical sequence shall add one total increment
+- repeated `||` operators in the same flattened logical sequence shall add one total increment
+- mixed `&&` and `||` sequences shall reset sequence counting boundaries and add an increment at each transition
 - negated logical groups shall reset sequence counting boundaries
+- optional chaining shall be ignored as shorthand
+- `??` shall be ignored as shorthand in default-value and non-default contexts
+- `??=`, `&&=`, and `||=` shall be ignored as assignment shorthand
 - JSX short-circuit rendering forms shall be ignored when they act as rendering shorthand
+
+These JavaScript and TypeScript operator semantics intentionally preserve the
+existing score model. They do not exactly mirror a single external tool: `&&`
+and `||` follow the Sonar white-paper-style transition model, while `??`,
+optional chaining, and logical assignment are treated as shorthand.
 
 ## 8. Recursion
 

--- a/tests/fixtures/compatibility-matrix/matrix.json
+++ b/tests/fixtures/compatibility-matrix/matrix.json
@@ -87,6 +87,26 @@
       ]
     },
     {
+      "name": "operator semantics",
+      "fixture": "compatibility-matrix/operator-semantics",
+      "expectedMetrics": [
+        { "name": "Widget", "cognitiveComplexity": 0 },
+        { "name": "Banner", "cognitiveComplexity": 2 },
+        { "name": "andRun", "cognitiveComplexity": 1 },
+        { "name": "orRun", "cognitiveComplexity": 1 },
+        { "name": "mixedTransitions", "cognitiveComplexity": 3 },
+        { "name": "defaultNullish", "cognitiveComplexity": 0 },
+        { "name": "nonDefaultNullish", "cognitiveComplexity": 0 },
+        { "name": "optionalAccess", "cognitiveComplexity": 0 },
+        { "name": "logicalAssignments", "cognitiveComplexity": 0 },
+        { "name": "negatedGroup", "cognitiveComplexity": 3 },
+        { "name": "nestedTernary", "cognitiveComplexity": 5 },
+        { "name": "switchDefault", "cognitiveComplexity": 1 },
+        { "name": "inner", "cognitiveComplexity": 1 },
+        { "name": "outer", "cognitiveComplexity": 0 }
+      ]
+    },
+    {
       "name": "nested functions",
       "fixture": "compatibility-matrix/nested-functions",
       "expectedMetrics": [

--- a/tests/fixtures/compatibility-matrix/operator-semantics/src/Widget.tsx
+++ b/tests/fixtures/compatibility-matrix/operator-semantics/src/Widget.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  ok: boolean;
+  label: string;
+}
+
+export const Widget = ({ ok, label }: Props) => (
+  <>{ok && <strong>{label}</strong>}</>
+);
+
+export const Banner = ({ ok, label }: Props) => (
+  <>{ok && (label ? <strong>{label}</strong> : <em>none</em>)}</>
+);

--- a/tests/fixtures/compatibility-matrix/operator-semantics/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/operator-semantics/src/sample.ts
@@ -1,0 +1,54 @@
+export function andRun(a: boolean, b: boolean, c: boolean, d: boolean): boolean {
+  return a && b && c && d;
+}
+
+export function orRun(a: boolean, b: boolean, c: boolean, d: boolean): boolean {
+  return a || b || c || d;
+}
+
+export function mixedTransitions(a: boolean, b: boolean, c: boolean, d: boolean): boolean {
+  return a && b || c && d;
+}
+
+export function defaultNullish(value?: string): string {
+  const label = value ?? "";
+  return label;
+}
+
+export function nonDefaultNullish(left?: string, right?: string): string | undefined {
+  return left ?? right;
+}
+
+export function optionalAccess(input?: { user?: { name?: string } }): string | undefined {
+  return input?.user?.name;
+}
+
+export function logicalAssignments(left: boolean | undefined, right: boolean): boolean | undefined {
+  left &&= right;
+  left ||= right;
+  left ??= right;
+  return left;
+}
+
+export function negatedGroup(a: boolean, b: boolean, c: boolean): number {
+  if (a && !(b && c)) {
+    return 1;
+  }
+  return 0;
+}
+
+export function nestedTernary(a: boolean, b: boolean, c: boolean): number {
+  return a ? (b ? 1 : 2) : c ? 3 : 4;
+}
+
+export function switchDefault(value: string): number {
+  switch (value) {
+    default:
+      return 0;
+  }
+}
+
+export function outer(a: boolean, b: boolean): boolean {
+  const inner = () => a && b;
+  return inner();
+}


### PR DESCRIPTION
## Summary
- Preserve current Cognitive Complexity operator semantics and pin them with dedicated tests.
- Add an operator-semantics compatibility fixture covering logical transitions, nullish/optional shorthand, logical assignment, JSX short-circuit rendering, nested functions, ternaries, and switch/default behavior.
- Document the decision and cross-tool comparison in the spec, compatibility matrix, and operator-semantics docs.
- Apply Prettier to the analyzer files that were already failing the current format gate on main.

## Review Focus
- Confirm the documented semantics match the intended #47 decision: `&&` / `||` transition-counted, `??`, `?.`, and logical assignment free.
- Check that the fixture expectations preserve existing scores rather than changing behavior.
- The analyzer source edits are mechanical Prettier output only.

## Validation
- `npm run build`
- `npm run lint`
- `npm run format:check` from a clean LF checkout
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces`

Closes #47