### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - No unreleased changes.
 
+## [0.2.1] - 2026-06-01
+
+### Changed
+
+- Updated compatible npm tooling and CI artifact action versions.
+- Hardened function discovery naming for namespace, class, object, class-field, computed-name, and assignment-target edge cases.
+- Documented and fixture-pinned Cognitive Complexity operator semantics while preserving existing default scores.
+
 ## [0.2.0] - 2026-05-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ CI expectations for pull requests:
 Before tagging a release, also run:
 
 ```bash
-npm run verify-release-version -- v0.2.0
+npm run verify-release-version -- v0.2.1
 ```
 
 The release workflow also renders the GitHub release notes from `CHANGELOG.md`, so unreleased notes need to be kept current before tagging.

--- a/README.md
+++ b/README.md
@@ -309,13 +309,13 @@ The earlier `v0.1.0` bootstrap used a one-time `NPM_TOKEN` secret so the public 
 Release notes can be rendered locally with:
 
 ```bash
-npm run render-release-notes -- v0.2.0
+npm run render-release-notes -- v0.2.1
 ```
 
 Before tagging a release, also verify the version metadata locally:
 
 ```bash
-npm run verify-release-version -- v0.2.0
+npm run verify-release-version -- v0.2.1
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cognitive-typescript-parent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cognitive-typescript-parent",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -6653,10 +6653,10 @@
     },
     "packages/cli": {
       "name": "@barney-media/cognitive-typescript",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.2.0"
+        "@barney-media/cognitive-typescript-core": "^0.2.1"
       },
       "bin": {
         "cognitive-typescript": "dist/bin.js"
@@ -6667,7 +6667,7 @@
     },
     "packages/core": {
       "name": "@barney-media/cognitive-typescript-core",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.7.2",
@@ -6679,10 +6679,10 @@
     },
     "packages/jest": {
       "name": "@barney-media/cognitive-typescript-jest",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.2.0"
+        "@barney-media/cognitive-typescript-core": "^0.2.1"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -6693,10 +6693,10 @@
     },
     "packages/vitest": {
       "name": "@barney-media/cognitive-typescript-vitest",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/cognitive-typescript-core": "^0.2.0"
+        "@barney-media/cognitive-typescript-core": "^0.2.1"
       },
       "engines": {
         "node": ">=22.13.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cognitive-typescript-parent",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Cognitive Complexity metrics for TypeScript",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI for Cognitive Complexity analysis in TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -42,6 +42,6 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.2.0"
+    "@barney-media/cognitive-typescript-core": "^0.2.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Core Cognitive Complexity analyzer for TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-jest",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Jest integration for cognitive-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -42,7 +42,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.2.0"
+    "@barney-media/cognitive-typescript-core": "^0.2.1"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/cognitive-typescript-vitest",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Vitest integration for cognitive-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -38,7 +38,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/cognitive-typescript-core": "^0.2.0"
+    "@barney-media/cognitive-typescript-core": "^0.2.1"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- Prepare the repository for the `v0.2.1` release.
- Update root and workspace package versions plus internal workspace dependency ranges to `0.2.1` / `^0.2.1`.
- Add the `0.2.1` changelog entry for #45, #46, and #47.
- Update release command examples to use `v0.2.1`.

## Review Focus
- Confirm all publishable workspace packages are versioned `0.2.1`.
- Confirm the CLI, Jest, and Vitest packages depend on `@barney-media/cognitive-typescript-core` `^0.2.1`.
- Confirm release notes accurately cover the unreleased changes shipping in this patch release.

## Validation
- `npm run build`
- `npm run lint`
- `npm run format:check` from a clean LF checkout
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces`
- `npm run verify-release-version -- v0.2.1`
- `npm run render-release-notes -- v0.2.1`

Closes #50