### PR TITLE
Reduce default Cognitive Complexity threshold to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
-- No unreleased changes.
+### Changed
+
+- Reduced the default Cognitive Complexity threshold from `15` to `8`.
 
 ## [0.2.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It performs pure static analysis using the Sonar Cognitive Complexity white pape
 - The implementation follows the SonarSource Cognitive Complexity white paper.
 - It is pure static analysis.
 - It does not execute tests, enable coverage, consume Istanbul or LCOV reports, or compute CRAP scores.
-- The default threshold is `15`, and the CLI and reporter integrations can override it.
+- The default threshold is `8`, and the CLI and reporter integrations can override it.
 
 ## Build and Test
 
@@ -97,7 +97,7 @@ npx cognitive-typescript src/server.ts packages/web
                              Omit redundant per-method status in the primary report
 --output <path>              Write the primary report to a file instead of stdout
 --junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
---threshold <integer>        Override the Cognitive Complexity threshold (default: 15)
+--threshold <integer>        Override the Cognitive Complexity threshold (default: 8)
 --agent                      Compact the primary report to actionable failures by default
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,7 +38,7 @@ npx cognitive-typescript --format json --output reports/cognitive.json --junit-r
                              Omit redundant per-method status in the primary report
 --output <path>              Write the primary report to a file instead of stdout
 --junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
---threshold <integer>        Override the Cognitive Complexity threshold (default: 15)
+--threshold <integer>        Override the Cognitive Complexity threshold (default: 8)
 --agent                      Compact the primary report to actionable failures by default
 ```
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -35,7 +35,7 @@ Options:
                              Enable conservative generated-code exclusions (default: true)
   --output <path>            Write the primary report to a file instead of stdout
   --junit-report <path>      Also write a full JUnit XML report for CI test-report UIs
-  --threshold <integer>      Override the Cognitive Complexity threshold (default: 15)
+  --threshold <integer>      Override the Cognitive Complexity threshold (default: 8)
 
 Behavior:
   (no args)                  Analyze all TypeScript files under any nested src/ tree

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,4 +1,4 @@
-export const COGNITIVE_COMPLEXITY_THRESHOLD = 15;
+export const COGNITIVE_COMPLEXITY_THRESHOLD = 8;
 export const NO_FILES_MESSAGE = "No TypeScript files to analyze.";
 export const NO_ANALYZABLE_FUNCTIONS_MESSAGE = "No function-like bodies to analyze.";
 

--- a/packages/core/src/functionDiscovery.ts
+++ b/packages/core/src/functionDiscovery.ts
@@ -398,15 +398,32 @@ function findContainerName(node: ts.Node, sourceFile: ts.SourceFile): string | n
   let current: ts.Node | undefined = node.parent;
   while (current) {
     if (ts.isObjectLiteralExpression(current)) {
-      const objectName = inferObjectContainerName(current, sourceFile);
-      return segments.length ? toDisplayName(objectName, segments.join(".")) : objectName;
+      return objectContainerName(current, segments, sourceFile);
     }
-    const segment = containerSegmentFromNode(current);
-    if (segment) {
-      segments.unshift(segment);
-    }
+    prependContainerSegment(segments, current);
     current = current.parent;
   }
+  return joinedSegments(segments);
+}
+
+function objectContainerName(
+  node: ts.ObjectLiteralExpression,
+  segments: readonly string[],
+  sourceFile: ts.SourceFile
+): string | null {
+  const objectName = inferObjectContainerName(node, sourceFile);
+  const nestedName = joinedSegments(segments);
+  return nestedName ? toDisplayName(objectName, nestedName) : objectName;
+}
+
+function prependContainerSegment(segments: string[], node: ts.Node): void {
+  const segment = containerSegmentFromNode(node);
+  if (segment) {
+    segments.unshift(segment);
+  }
+}
+
+function joinedSegments(segments: readonly string[]): string | null {
   return segments.length ? segments.join(".") : null;
 }
 

--- a/packages/core/test/analysis.test.ts
+++ b/packages/core/test/analysis.test.ts
@@ -44,7 +44,7 @@ export function second(flag: boolean): number {
     expect(result.thresholdExceeded).toBe(false);
   });
 
-  it("reports threshold failures when any function exceeds 15", async () => {
+  it("reports threshold failures when any function exceeds the default threshold", async () => {
     const projectRoot = await createTempDir("cognitive-analysis-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -124,7 +124,7 @@ describe("cli", () => {
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toBe(
       "status: passed\n" +
-        "threshold: 15\n" +
+        "threshold: 8\n" +
         "methods[0]:\n" +
         "exclusions:\n" +
         "  discoveredFiles: 0\n" +
@@ -174,7 +174,7 @@ describe("cli", () => {
 
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toContain("tooComplex");
-    expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded: 28 > 15");
+    expect(stderr.toString()).toContain("Cognitive Complexity threshold exceeded: 28 > 8");
   });
 
   it("uses configured thresholds for exit code decisions", async () => {
@@ -192,6 +192,14 @@ describe("cli", () => {
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("threshold: 30");
     expect(stderr.toString()).toBe("");
+
+    const oldDefaultStdout = new StringWriter();
+    const oldDefaultStderr = new StringWriter();
+    const oldDefaultExitCode = await runCli(["--threshold=15"], projectRoot, oldDefaultStdout, oldDefaultStderr);
+
+    expect(oldDefaultExitCode).toBe(2);
+    expect(oldDefaultStdout.toString()).toContain("threshold: 15");
+    expect(oldDefaultStderr.toString()).toContain("Cognitive Complexity threshold exceeded: 28 > 15");
   });
 
   it("writes primary output files and full JUnit sidecars", async () => {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -58,7 +58,7 @@ describe("report formatting", () => {
     ]);
 
     expect(report.status).toBe("failed");
-    expect(report.threshold).toBe(15);
+    expect(report.threshold).toBe(8);
     expect(report.methods).toEqual([
       {
         status: "failed",
@@ -107,7 +107,7 @@ describe("report formatting", () => {
       )
     ).toEqual({
       status: "failed",
-      threshold: 15,
+      threshold: 8,
       methods: [
         {
           status: "failed",
@@ -120,8 +120,8 @@ describe("report formatting", () => {
       ],
       exclusions: audit()
     });
-    expect(formatTextReport(buildAnalysisReport(metrics, 15, false, audit()))).toContain("exclusions:");
-    expect(formatToonReport(buildAnalysisReport(metrics, 15, false, audit()))).toContain("exclusions:");
+    expect(formatTextReport(buildAnalysisReport(metrics, 8, false, audit()))).toContain("exclusions:");
+    expect(formatToonReport(buildAnalysisReport(metrics, 8, false, audit()))).toContain("exclusions:");
   });
 
   it("omits TOON exclusion lines when no audit is present", () => {
@@ -138,7 +138,7 @@ describe("report formatting", () => {
     ) as { status: string; threshold: number; methods: Array<Record<string, unknown>> };
 
     expect(parsed.status).toBe("failed");
-    expect(parsed.threshold).toBe(15);
+    expect(parsed.threshold).toBe(8);
     expect(parsed.methods).toEqual([
       expect.objectContaining({
         method: "risky",
@@ -149,7 +149,7 @@ describe("report formatting", () => {
   });
 
   it("uses agent as failures-only plus omit-redundancy defaults", () => {
-    const report = buildAgentAnalysisReport([metric(), metric({ displayName: "risky", cognitiveComplexity: 16 })], 15);
+    const report = buildAgentAnalysisReport([metric(), metric({ displayName: "risky", cognitiveComplexity: 16 })], 8);
     const parsed = JSON.parse(
       formatAnalysisReport([metric(), metric({ displayName: "risky", cognitiveComplexity: 16 })], {
         format: "json",
@@ -166,9 +166,9 @@ describe("report formatting", () => {
   });
 
   it("can include exclusion audit in compact reports when explicitly requested", () => {
-    expect(buildAgentAnalysisReport([metric({ displayName: "risky", cognitiveComplexity: 16 })], 15, audit())).toEqual({
+    expect(buildAgentAnalysisReport([metric({ displayName: "risky", cognitiveComplexity: 16 })], 8, audit())).toEqual({
       status: "failed",
-      threshold: 15,
+      threshold: 8,
       methods: [
         {
           cc: 16,
@@ -183,9 +183,9 @@ describe("report formatting", () => {
   });
 
   it("does not add a blank separator before exclusions when there are no methods", () => {
-    expect(formatTextReport(buildAnalysisReport([], 15, false, audit()))).toBe(
+    expect(formatTextReport(buildAnalysisReport([], 8, false, audit()))).toBe(
       "status: passed\n" +
-        "threshold: 15\n" +
+        "threshold: 8\n" +
         "methods[0]:\n" +
         "exclusions:\n" +
         "  discoveredFiles: 3\n" +
@@ -209,7 +209,7 @@ describe("report formatting", () => {
           }),
           metric()
         ],
-        15,
+        8,
         false,
         audit()
       ),
@@ -227,7 +227,7 @@ describe("report formatting", () => {
     expect(output).toContain('<property name="exclusion.discoveredFiles" value="3"/>');
     expect(output).toContain('<property name="exclusion.excludedFunctions" value="1"/>');
     expect(output).toContain("Cognitive Complexity: 16");
-    expect(output).toContain("Threshold: 15");
+    expect(output).toContain("Threshold: 8");
     expect(output).toContain("<system-out>Cognitive Complexity: 16");
     expect(output).toContain("<system-out>Cognitive Complexity: 1");
     expect(output).toContain("Source: src/quoted&amp;file.ts:1-3");

--- a/spec.md
+++ b/spec.md
@@ -10,7 +10,7 @@ It shall:
 - parse function-like bodies with the TypeScript compiler API
 - compute Cognitive Complexity using the Sonar white-paper rules, with TypeScript-specific derivations
 - report the worst functions first
-- fail when any analyzed function exceeds the fixed threshold of `8`
+- fail when any analyzed function exceeds the configured threshold, which defaults to `8`
 
 ## 2. Scope
 
@@ -27,7 +27,6 @@ This specification defines:
 
 This specification does not define:
 
-- configurable thresholds
 - coverage processing
 - non-TypeScript source analysis
 - machine-readable report formats
@@ -211,11 +210,11 @@ If files are selected but no function-like bodies are analyzable:
 
 ## 10. Threshold
 
-The fixed threshold shall be `8`.
+The default threshold shall be `8`. A finite positive threshold may be configured.
 
-If the maximum Cognitive Complexity exceeds `8`:
+If the maximum Cognitive Complexity exceeds the configured threshold:
 
-- the CLI shall print `Cognitive Complexity threshold exceeded: <max> > 8` to stderr
+- the CLI shall print `Cognitive Complexity threshold exceeded: <max> > <threshold>` to stderr
 - the CLI shall exit with code `2`
 
 Otherwise the CLI shall exit with code `0`.

--- a/spec.md
+++ b/spec.md
@@ -10,7 +10,7 @@ It shall:
 - parse function-like bodies with the TypeScript compiler API
 - compute Cognitive Complexity using the Sonar white-paper rules, with TypeScript-specific derivations
 - report the worst functions first
-- fail when any analyzed function exceeds the fixed threshold of `15`
+- fail when any analyzed function exceeds the fixed threshold of `8`
 
 ## 2. Scope
 
@@ -211,11 +211,11 @@ If files are selected but no function-like bodies are analyzable:
 
 ## 10. Threshold
 
-The fixed threshold shall be `15`.
+The fixed threshold shall be `8`.
 
-If the maximum Cognitive Complexity exceeds `15`:
+If the maximum Cognitive Complexity exceeds `8`:
 
-- the CLI shall print `Cognitive Complexity threshold exceeded: <max> > 15` to stderr
+- the CLI shall print `Cognitive Complexity threshold exceeded: <max> > 8` to stderr
 - the CLI shall exit with code `2`
 
 Otherwise the CLI shall exit with code `0`.

--- a/spec.md
+++ b/spec.md
@@ -210,7 +210,7 @@ If files are selected but no function-like bodies are analyzable:
 
 ## 10. Threshold
 
-The default threshold shall be `8`. A finite positive threshold may be configured.
+The default threshold shall be `8`. A positive integer threshold may be configured.
 
 If the maximum Cognitive Complexity exceeds the configured threshold:
 


### PR DESCRIPTION
## Summary
- Reduce the default Cognitive Complexity threshold from `15` to `8` across constants, CLI help, docs, spec, changelog, and tests.
- Refactor `findContainerName` into small helpers so the repository self-gate passes at the new threshold.
- Preserve explicit threshold override behavior with coverage for `--threshold=15`.

Closes #59

## Validation
- `git diff --check`
- `npm ci`
- `npm run build`
- `npm run lint`
- `npm exec prettier -- --check <changed TypeScript files>`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces --pack-destination %TEMP%\\cognitive-typescript-59-pack`

Note: local `npm run format:check` reports repository-wide CRLF/pre-existing formatting drift on this Windows checkout; changed TypeScript files were checked directly with Prettier.
